### PR TITLE
Expose locals as parameters to _syncAnimationSizes()

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1191,7 +1191,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
    * @private
    * Keep animation properties in sync with how the animation changes.
    */
-  this._syncAnimationSizes = function() {
+  this._syncAnimationSizes = function(animations, currentAnimation) {
     //has an animation but the collider is still default
     //the animation wasn't loaded. if the animation is not a 1x1 image
     //it means it just finished loading
@@ -1256,7 +1256,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
         //update it
         animations[currentAnimation].update();
 
-        this._syncAnimationSizes();
+        this._syncAnimationSizes(animations, currentAnimation);
       }
 
       //a collider is created either manually with setCollider or


### PR DESCRIPTION
For some reason this shows up in https://github.com/code-dot-org/code-dot-org/pull/9546 but not in its matching upstream change https://github.com/molleindustria/p5.play/pull/103.  It's necessary for code-dot-org's wrapper.