### PR TITLE
Publish to npm

### DIFF
--- a/ensure-cdo-version.js
+++ b/ensure-cdo-version.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/*
+  Check whether package.json's version number contains a -cdo prerelease tag.
+  This should run during the `npm version` step, and helps ensure we keep our
+  version ids separate from the upstream project.
+*/
+var fs = require('fs');
+
+try {
+  var packageInfo = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+  // If the version id starts with #.#.#-cdo then we're all good.
+  if (/^\d+\.\d+\.\d+-cdo/.test(packageInfo.version)) {
+    process.exit();
+  }
+
+  console.error('The version id "' + packageInfo.version + '" is not valid.');
+  console.error('This package requires version ids to contain a "-cdo" tag, to keep them separate from the upstream project (e.g. "1.0.0-cdo").');
+  process.exit(1);
+} catch (e) {
+  console.error('There was an error while checking the new version number: ' + e);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "p5.play",
-  "version": "1.0.0",
-  "description": "A p5.js library for the creation of games and playthings.",
+  "name": "@code-dot-org/p5.play",
+  "version": "1.0.0-cdo",
+  "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {
     "eslint": "^3.1.0",
@@ -12,6 +12,10 @@
   "engines": {
     "node" : ">=4.0.0"
   },
+  "files": [
+    "lib/p5.play.js",
+    "examples/lib/p5.js"
+  ],
   "scripts": {
     "docs": "yuidoc .",
     "lint": "eslint lib/** test/unit/** examples/*.js",
@@ -20,16 +24,28 @@
     "lint:test": "eslint test/unit/**",
     "start": "http-server -o",
     "pretest": "npm run lint",
-    "test": "mocha-phantomjs test/index.html"
+    "test": "mocha-phantomjs test/index.html",
+    "preversion": "npm whoami && npm test",
+    "version": "node ensure-cdo-version.js",
+    "postversion": "git push && git push --tags && npm publish"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/molleindustria/p5.play.git"
+    "url": "git+https://github.com/code-dot-org/p5.play.git"
   },
   "author": "Paolo Pedercini <info@molleindustria.it>",
+  "contributors": [
+    "Atul Varma <varmaa@gmail.com>",
+    "Brad Buchanan <brad@code.org>",
+    "Caley Brock <caley@code.org>",
+    "Chris Pirich <chris@code.org>",
+    "Dan Bernier <danbernier@gmail.com>",
+    "Henry Lake",
+    "Jared Sprague",
+    "Josh Lory <josh.lory@code.org>",
+    "Leaps <lmtejedor@gmail.com>",
+    "Michael Clayton <mwc@clayto.com>"
+  ],
   "license": "LGPL-2.1",
-  "bugs": {
-    "url": "https://github.com/molleindustria/p5.play/issues"
-  },
-  "homepage": "https://github.com/molleindustria/p5.play#readme"
+  "homepage": "https://github.com/code-dot-org/p5.play#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.0.0-cdo",
+  "version": "1.0.1-cdo.testing",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {
@@ -10,7 +10,7 @@
     "yuidocjs": "^0.10.0"
   },
   "engines": {
-    "node" : ">=4.0.0"
+    "node": ">=4.0.0"
   },
   "files": [
     "lib/p5.play.js",


### PR DESCRIPTION
We'll be publishing this package on npm as [`@code-dot-org/p5.play`](https://www.npmjs.com/package/@code-dot-org/p5.play) to avoid a collision if @molleindustria wishes to publish the main project someday. In addition, we will only be publishing versions with `-cdo` [prerelease tags](https://docs.npmjs.com/misc/semver#prerelease-tags) to avoid version numbering collisions with the main project.

I've updated the package.json to point to our own repositories, etc, to credit known contributors, and to whiteliest the p5.js and p5.play.js files so that a minimum amount of content is actually pushed to npm.  To publish a new version one will run `npm version <new version id>` where the new id must take the form `#.#.#-cdo*`.  This will run all tests to verify the state of the library, apply the new version number, push new tags to GitHub and new content to npm.

If we like this approach of tagging our versions of forked projects, we should be able to reuse the `ensure-cdo-version.js` script included here.