### PR TITLE
Scale colliders correctly

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4467,7 +4467,11 @@ p5.prototype._warn = function(message) {
    */
   p5.CircleCollider.prototype.updateFromSprite = function(sprite) {
     if (this.getsDimensionsFromSprite) {
-      this.radius = Math.max(sprite.width, sprite.height)/2;
+      if (sprite.animation) {
+        this.radius = Math.max(sprite.animation.getWidth(), sprite.animation.getHeight())/2;
+      } else {
+        this.radius = Math.max(sprite.width, sprite.height)/2;
+      }
     }
     this.setParentTransform(sprite);
   };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4700,8 +4700,13 @@ p5.prototype._warn = function(message) {
    */
   p5.AxisAlignedBoundingBoxCollider.prototype.updateFromSprite = function(sprite) {
     if (this.getsDimensionsFromSprite) {
-      this._width = sprite.width;
-      this._height = sprite.height;
+      if (sprite.animation) {
+        this._width = sprite.animation.getWidth();
+        this._height = sprite.animation.getHeight();
+      } else {
+        this._width = sprite.width;
+        this._height = sprite.height;
+      }
     }
     this.setParentTransform(sprite);
   };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4933,8 +4933,13 @@ p5.prototype._warn = function(message) {
    */
   p5.OrientedBoundingBoxCollider.prototype.updateFromSprite = function(sprite) {
     if (this.getsDimensionsFromSprite) {
-      this._width = sprite.width;
-      this._height = sprite.height;
+      if (sprite.animation) {
+        this._width = sprite.animation.getWidth();
+        this._height = sprite.animation.getHeight();
+      } else {
+        this._width = sprite.width;
+        this._height = sprite.height;
+      }
     }
     this.setParentTransform(sprite);
   };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4931,18 +4931,8 @@ p5.prototype._warn = function(message) {
    * @param {Sprite} sprite
    * @see p5.CollisionShape.prototype.getsDimensionsFromSprite
    */
-  p5.OrientedBoundingBoxCollider.prototype.updateFromSprite = function(sprite) {
-    if (this.getsDimensionsFromSprite) {
-      if (sprite.animation) {
-        this._width = sprite.animation.getWidth();
-        this._height = sprite.animation.getHeight();
-      } else {
-        this._width = sprite.width;
-        this._height = sprite.height;
-      }
-    }
-    this.setParentTransform(sprite);
-  };
+  p5.OrientedBoundingBoxCollider.prototype.updateFromSprite =
+    p5.AxisAlignedBoundingBoxCollider.prototype.updateFromSprite;
 
   /**
    * Recalculate cached properties, relevant vectors, etc. when at least one
@@ -5022,14 +5012,10 @@ p5.prototype._warn = function(message) {
    * @param {p5.Vector} axis
    * @return {number}
    */
-  p5.OrientedBoundingBoxCollider.prototype._getRadiusOnAxis = function(axis) {
-    // How to project a rect onto an axis:
-    // Project the center-corner vectors for two adjacent corners (cached here)
-    // onto the axis.  The larger magnitude of the two is your projection's radius.
-    return Math.max(
-      p5.Vector.project(this._halfDiagonals[0], axis).mag(),
-      p5.Vector.project(this._halfDiagonals[1], axis).mag());
-  };
+  p5.OrientedBoundingBoxCollider.prototype._getRadiusOnAxis =
+    p5.AxisAlignedBoundingBoxCollider.prototype._getRadiusOnAxis;
+  // We can reuse the AABB version of this method because both are projecting
+  // cached half-diagonals - the same code works.
 
   /**
    * A 2D affine transformation (translation, rotation, scale) stored as a

--- a/test/unit/axis-aligned-bounding-box.js
+++ b/test/unit/axis-aligned-bounding-box.js
@@ -66,4 +66,209 @@ describe('AxisAlignedBoundingBoxCollider', function() {
     expect(displacement.x).to.be.closeTo(0, MARGIN_OF_ERROR);
     expect(displacement.y).to.be.closeTo(-1, MARGIN_OF_ERROR);
   });
+
+  describe('updateFromSprite()', function() {
+    var pInst, testAnimation;
+
+    beforeEach(function() {
+      pInst = new p5(function() {});
+      testAnimation = createTestAnimation(3);
+    });
+
+    afterEach(function() {
+      pInst.remove();
+    });
+
+    it('adopts dimensions from animationless sprite when no dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.setCollider('aabb');
+      expect(sprite.collider.width).to.equal(200);
+      expect(sprite.collider.height).to.equal(210);
+      expect(sprite.collider.getBoundingBox().width).to.equal(200);
+      expect(sprite.collider.getBoundingBox().height).to.equal(210);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(300);
+      expect(sprite.collider.height).to.equal(310);
+      expect(sprite.collider.getBoundingBox().width).to.equal(300);
+      expect(sprite.collider.getBoundingBox().height).to.equal(310);
+    });
+
+    it('keeps own dimensions from animationless sprite when dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.setCollider('aabb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+    });
+
+    it('adopts scaled dimensions from animationless sprite when no dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.scale = 2;
+      sprite.setCollider('aabb');
+      expect(sprite.collider.width).to.equal(200);
+      expect(sprite.collider.height).to.equal(210);
+      expect(sprite.collider.getBoundingBox().width).to.equal(400);
+      expect(sprite.collider.getBoundingBox().height).to.equal(420);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(300);
+      expect(sprite.collider.height).to.equal(310);
+      expect(sprite.collider.getBoundingBox().width).to.equal(600);
+      expect(sprite.collider.getBoundingBox().height).to.equal(620);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(300);
+      expect(sprite.collider.height).to.equal(310);
+      expect(sprite.collider.getBoundingBox().width).to.equal(900);
+      expect(sprite.collider.getBoundingBox().height).to.equal(930);
+    });
+
+    it('scales own dimensions from animationless sprite when dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.scale = 2;
+      sprite.setCollider('aabb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(75);
+      expect(sprite.collider.getBoundingBox().height).to.equal(105);
+    });
+
+    it('adopts animation dimensions from sprite with animation when no dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.setCollider('aabb');
+      // Frames in the test animation are 50x55
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(55);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(55);
+    });
+
+    it('keeps own dimensions from sprite with animation when dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.setCollider('aabb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+    });
+
+    it('adopts scaled animation dimensions from sprite with animation when no dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.scale = 2;
+      sprite.setCollider('aabb');
+      // Frames in the test animation are 50x55
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(100);
+      expect(sprite.collider.getBoundingBox().height).to.equal(110);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(100);
+      expect(sprite.collider.getBoundingBox().height).to.equal(110);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(150);
+      expect(sprite.collider.getBoundingBox().height).to.equal(165);
+    });
+
+    it('scales own dimensions from sprite with animation when dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.scale = 2;
+      sprite.setCollider('aabb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(75);
+      expect(sprite.collider.getBoundingBox().height).to.equal(105);
+    });
+
+    /**
+     * Makes a fake animation with the specified number of frames.
+     * @param {number} frameCount
+     * @returns {p5.Animation}
+     */
+    function createTestAnimation(frameCount) {
+      frameCount = frameCount || 1;
+      var image = new p5.Image(100, 100, pInst);
+      var frames = [];
+      for (var i = 0; i < frameCount; i++) {
+        frames.push({name: i, frame: {x: 0, y: 0, width: 50, height: 55}});
+      }
+      var sheet = new pInst.SpriteSheet(image, frames);
+      var animation = new pInst.Animation(sheet);
+      animation.frameDelay = 1;
+      return animation;
+    }
+  });
 });

--- a/test/unit/collision-circle.js
+++ b/test/unit/collision-circle.js
@@ -120,4 +120,80 @@ describe('CircleCollider', function() {
       expect(displacement.y / displacement.x).to.closeTo(2 / 6, MARGIN_OF_ERROR);
     });
   });
+
+  describe('updateFromSprite()', function() {
+    var pInst;
+
+    beforeEach(function() {
+      pInst = new p5(function() {});
+    });
+
+    afterEach(function() {
+      pInst.remove();
+    });
+
+    it('adopts scaled radius from animationless sprite when no radius is given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.setCollider('circle');
+      expect(sprite.collider.radius).to.equal(100);
+      expect(sprite.collider._scaledRadius).to.equal(100);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(150)
+      expect(sprite.collider._scaledRadius).to.equal(150);
+    });
+
+    it('keeps own radius from animationless sprite when radius is given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.setCollider('circle', 0, 0, 25);
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(25);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(25)
+      expect(sprite.collider._scaledRadius).to.equal(25);
+    });
+
+    it('adopts scaled radius from animationless sprite when no radius is given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.scale = 2;
+      sprite.setCollider('circle');
+      expect(sprite.collider.radius).to.equal(100);
+      expect(sprite.collider._scaledRadius).to.equal(200);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(150);
+      expect(sprite.collider._scaledRadius).to.equal(300);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(150);
+      expect(sprite.collider._scaledRadius).to.equal(450);
+    });
+
+    it('doubles own radius from animationless sprite when radius is given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.scale = 2;
+      sprite.setCollider('circle', 0, 0, 25);
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(50);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(50);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(75);
+    });
+  });
 });

--- a/test/unit/collision-circle.js
+++ b/test/unit/collision-circle.js
@@ -133,7 +133,7 @@ describe('CircleCollider', function() {
       pInst.remove();
     });
 
-    it('adopts scaled radius from animationless sprite when no radius is given, scale 1', function() {
+    it('adopts radius from animationless sprite when no radius is given, scale 1', function() {
       var sprite = pInst.createSprite(0, 0, 200, 200);
       sprite.setCollider('circle');
       expect(sprite.collider.radius).to.equal(100);

--- a/test/unit/collision-circle.js
+++ b/test/unit/collision-circle.js
@@ -122,10 +122,11 @@ describe('CircleCollider', function() {
   });
 
   describe('updateFromSprite()', function() {
-    var pInst;
+    var pInst, testAnimation;
 
     beforeEach(function() {
       pInst = new p5(function() {});
+      testAnimation = createTestAnimation(3);
     });
 
     afterEach(function() {
@@ -141,7 +142,7 @@ describe('CircleCollider', function() {
       sprite.width = 300;
       sprite.height = 300;
       sprite.update();
-      expect(sprite.collider.radius).to.equal(150)
+      expect(sprite.collider.radius).to.equal(150);
       expect(sprite.collider._scaledRadius).to.equal(150);
     });
 
@@ -154,7 +155,7 @@ describe('CircleCollider', function() {
       sprite.width = 300;
       sprite.height = 300;
       sprite.update();
-      expect(sprite.collider.radius).to.equal(25)
+      expect(sprite.collider.radius).to.equal(25);
       expect(sprite.collider._scaledRadius).to.equal(25);
     });
 
@@ -177,7 +178,7 @@ describe('CircleCollider', function() {
       expect(sprite.collider._scaledRadius).to.equal(450);
     });
 
-    it('doubles own radius from animationless sprite when radius is given, scale != 1', function() {
+    it('scales own radius from animationless sprite when radius is given, scale != 1', function() {
       var sprite = pInst.createSprite(0, 0, 200, 200);
       sprite.scale = 2;
       sprite.setCollider('circle', 0, 0, 25);
@@ -195,5 +196,94 @@ describe('CircleCollider', function() {
       expect(sprite.collider.radius).to.equal(25);
       expect(sprite.collider._scaledRadius).to.equal(75);
     });
+
+    it('adopts animation radius from sprite with animation when no radius is given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.setCollider('circle');
+      // Frames in the test animation are 50x50
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(25);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(25);
+    });
+
+    it('keeps own radius from sprite with animation when radius is given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.setCollider('circle', 0, 0, 40);
+      expect(sprite.collider.radius).to.equal(40);
+      expect(sprite.collider._scaledRadius).to.equal(40);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(40);
+      expect(sprite.collider._scaledRadius).to.equal(40);
+    });
+
+    it('adopts scaled animation radius from sprite with animation when no radius is given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.scale = 2;
+      sprite.setCollider('circle');
+      // Frames in the test animation are 50x50
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(50);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(50);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(25);
+      expect(sprite.collider._scaledRadius).to.equal(75);
+    });
+
+    it('scales own radius from sprite with animation when radius is given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.scale = 2;
+      sprite.setCollider('circle', 0, 0, 40);
+      expect(sprite.collider.radius).to.equal(40);
+      expect(sprite.collider._scaledRadius).to.equal(80);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(40);
+      expect(sprite.collider._scaledRadius).to.equal(80);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.radius).to.equal(40);
+      expect(sprite.collider._scaledRadius).to.equal(120);
+    });
+
+    /**
+     * Makes a fake animation with the specified number of frames.
+     * @param {number} frameCount
+     * @returns {p5.Animation}
+     */
+    function createTestAnimation(frameCount) {
+      frameCount = frameCount || 1;
+      var image = new p5.Image(100, 100, pInst);
+      var frames = [];
+      for (var i = 0; i < frameCount; i++) {
+        frames.push({name: i, frame: {x: 0, y: 0, width: 50, height: 50}});
+      }
+      var sheet = new pInst.SpriteSheet(image, frames);
+      var animation = new pInst.Animation(sheet);
+      animation.frameDelay = 1;
+      return animation;
+    }
   });
 });
+

--- a/test/unit/oriented-bounding-box.js
+++ b/test/unit/oriented-bounding-box.js
@@ -314,4 +314,209 @@ describe('OrientedBoundingBoxCollider', function() {
       expect(candidateAxes.length).to.equal(2);
     });
   });
+
+  describe('updateFromSprite()', function() {
+    var pInst, testAnimation;
+
+    beforeEach(function() {
+      pInst = new p5(function() {});
+      testAnimation = createTestAnimation(3);
+    });
+
+    afterEach(function() {
+      pInst.remove();
+    });
+
+    it('adopts dimensions from animationless sprite when no dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.setCollider('obb');
+      expect(sprite.collider.width).to.equal(200);
+      expect(sprite.collider.height).to.equal(210);
+      expect(sprite.collider.getBoundingBox().width).to.equal(200);
+      expect(sprite.collider.getBoundingBox().height).to.equal(210);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(300);
+      expect(sprite.collider.height).to.equal(310);
+      expect(sprite.collider.getBoundingBox().width).to.equal(300);
+      expect(sprite.collider.getBoundingBox().height).to.equal(310);
+    });
+
+    it('keeps own dimensions from animationless sprite when dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.setCollider('obb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+    });
+
+    it('adopts scaled dimensions from animationless sprite when no dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.scale = 2;
+      sprite.setCollider('obb');
+      expect(sprite.collider.width).to.equal(200);
+      expect(sprite.collider.height).to.equal(210);
+      expect(sprite.collider.getBoundingBox().width).to.equal(400);
+      expect(sprite.collider.getBoundingBox().height).to.equal(420);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(300);
+      expect(sprite.collider.height).to.equal(310);
+      expect(sprite.collider.getBoundingBox().width).to.equal(600);
+      expect(sprite.collider.getBoundingBox().height).to.equal(620);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(300);
+      expect(sprite.collider.height).to.equal(310);
+      expect(sprite.collider.getBoundingBox().width).to.equal(900);
+      expect(sprite.collider.getBoundingBox().height).to.equal(930);
+    });
+
+    it('scales own dimensions from animationless sprite when dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.scale = 2;
+      sprite.setCollider('obb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(75);
+      expect(sprite.collider.getBoundingBox().height).to.equal(105);
+    });
+
+    it('adopts animation dimensions from sprite with animation when no dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.setCollider('obb');
+      // Frames in the test animation are 50x55
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(55);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(55);
+    });
+
+    it('keeps own dimensions from sprite with animation when dimensions are given, scale 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.setCollider('obb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(25);
+      expect(sprite.collider.getBoundingBox().height).to.equal(35);
+    });
+
+    it('adopts scaled animation dimensions from sprite with animation when no dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 210);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.scale = 2;
+      sprite.setCollider('obb');
+      // Frames in the test animation are 50x55
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(100);
+      expect(sprite.collider.getBoundingBox().height).to.equal(110);
+
+      sprite.width = 300;
+      sprite.height = 310;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(100);
+      expect(sprite.collider.getBoundingBox().height).to.equal(110);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(50);
+      expect(sprite.collider.height).to.equal(55);
+      expect(sprite.collider.getBoundingBox().width).to.equal(150);
+      expect(sprite.collider.getBoundingBox().height).to.equal(165);
+    });
+
+    it('scales own dimensions from sprite with animation when dimensions are given, scale != 1', function() {
+      var sprite = pInst.createSprite(0, 0, 200, 200);
+      sprite.addAnimation('testAnim', testAnimation);
+      sprite.scale = 2;
+      sprite.setCollider('obb', 0, 0, 25, 35);
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.width = 300;
+      sprite.height = 300;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(50);
+      expect(sprite.collider.getBoundingBox().height).to.equal(70);
+
+      sprite.scale = 3;
+      sprite.update();
+      expect(sprite.collider.width).to.equal(25);
+      expect(sprite.collider.height).to.equal(35);
+      expect(sprite.collider.getBoundingBox().width).to.equal(75);
+      expect(sprite.collider.getBoundingBox().height).to.equal(105);
+    });
+
+    /**
+     * Makes a fake animation with the specified number of frames.
+     * @param {number} frameCount
+     * @returns {p5.Animation}
+     */
+    function createTestAnimation(frameCount) {
+      frameCount = frameCount || 1;
+      var image = new p5.Image(100, 100, pInst);
+      var frames = [];
+      for (var i = 0; i < frameCount; i++) {
+        frames.push({name: i, frame: {x: 0, y: 0, width: 50, height: 55}});
+      }
+      var sheet = new pInst.SpriteSheet(image, frames);
+      var animation = new pInst.Animation(sheet);
+      animation.frameDelay = 1;
+      return animation;
+    }
+  });
 });


### PR DESCRIPTION
Because the `Sprite` class is not guaranteed to be internally consistent, we have to give our colliders a bit of knowledge about animations in order for them to scale correctly on sprites with animations.

# The problem
A demonstration of Sprite's lack of internal consistency (assume the test animation is 30x30 and has a frameDelay of 1):
```javascript
// Point-in-time values for sprite:      sprite.width, sprite.height, sprite.scale
var s = createSprite(0, 0, 100, 100); // 100           100            1
s.scale = 2;                          // 100           100            2
s.update();                           // 100           100            2
s.setAnimation(anim30x30);            // 60            60             2
s.scale = 3;                          // 60            60             3
s.update();                           // 90            90             3
```
You can see that there's no guaranteed way to calculate the sprite's unscaled dimensions at all points in time, using the sprite dimensions and scale properties alone.  Instead, our colliders now check whether a sprite has an animation when updating, and and use the animation's unscaled dimensions as the sprite's unscaled dimensions (which is the eventual goal anyway).

# Demo
Here's a set of sprites at different scales, using colliders without explicit dimensions (which was the problem case) and you can see that the colliders match the sprite sizes.  Note that the order of calls to setup the sprite is different for the squares and circles.

![scaled_colliders_fixed](https://cloud.githubusercontent.com/assets/1615761/20124731/735ce85e-a5dd-11e6-9480-e9ef4d9eba02.gif)
