### PR TITLE
Update multisampling of OBB collisions to prevent tunneling

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2314,8 +2314,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
       // when objects end up at very high velocities (as happens sometimes in
       // game engines).
       var radiusOnVelocityAxis = Math.max(
-        this.collider._getTunnelRadiusOnAxis(relativeVelocity),
-        target.collider._getTunnelRadiusOnAxis(relativeVelocity));
+        this.collider._getMinRadius(),
+        target.collider._getMinRadius());
       var timestep = Math.max(0.015, radiusOnVelocityAxis / Math.sqrt(squareVelocity));
       // If the objects are small enough to benefit from multisampling at this
       // relative velocity
@@ -4319,15 +4319,15 @@ p5.prototype._warn = function(message) {
   };
 
   /**
-   * Get the shape's radius for tunneling checks along a given axis. For most
-   * colliders this is the same as `_getRadiusOnAxis`.
-   * @method _getTunnelRadiusOnAxis
+   * Get the shape's minimum radius on any axis for tunneling checks.
+   * @method _getMinRadius
    * @protected
    * @param {p5.Vector} axis
    * @return {number}
    */
-  p5.CollisionShape.prototype._getTunnelRadiusOnAxis =
-    p5.CollisionShape.prototype._getRadiusOnAxis;
+  p5.CollisionShape.prototype._getMinRadius = function() {
+    return 0;
+  };
 
   /**
    * @property X_AXIS
@@ -4587,6 +4587,17 @@ p5.prototype._warn = function(message) {
   };
 
   /**
+   * Get the shape's minimum radius on any axis for tunneling checks.
+   * @method _getMinRadius
+   * @protected
+   * @param {p5.Vector} axis
+   * @return {number}
+   */
+  p5.CircleCollider.prototype._getMinRadius = function() {
+    return this._scaledRadius;
+  };
+
+  /**
    * An Axis-Aligned Bounding Box (AABB) collision shape, used to detect overlap
    * and compute minimum displacement vectors with other collision shapes.
    *
@@ -4811,6 +4822,17 @@ p5.prototype._warn = function(message) {
   };
 
   /**
+   * Get the shape's minimum radius on any axis for tunneling checks.
+   * @method _getMinRadius
+   * @protected
+   * @param {p5.Vector} axis
+   * @return {number}
+   */
+  p5.AxisAlignedBoundingBoxCollider.prototype._getMinRadius = function() {
+    return Math.min(this._width, this._height);
+  };
+
+  /**
    * An Oriented Bounding Box (OBB) collision shape, used to detect overlap and
    * compute minimum displacement vectors with other collision shapes.
    * @class p5.OrientedBoundingBoxCollider
@@ -5031,14 +5053,13 @@ p5.prototype._warn = function(message) {
   /**
    * When checking for tunneling through a OrientedBoundingBoxCollider use a
    * worst-case of zero (e.g. if the other sprite is passing through a corner).
-   * @method _getTunnelRadiusOnAxis
+   * @method _getMinRadius
    * @protected
    * @param {p5.Vector} axis
    * @return {number}
    */
-  p5.OrientedBoundingBoxCollider.prototype._getTunnelRadiusOnAxis = function() {
-    return 0;
-  };
+  p5.OrientedBoundingBoxCollider.prototype._getMinRadius =
+    p5.AxisAlignedBoundingBoxCollider.prototype._getMinRadius;
 
   /**
    * A 2D affine transformation (translation, rotation, scale) stored as a

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2313,9 +2313,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
       // We want to limit this so that we don't take an absurd number of samples
       // when objects end up at very high velocities (as happens sometimes in
       // game engines).
-      var radiusOnVelocityAxis = Math.max(
-        this.collider._getRadiusOnAxis(relativeVelocity),
-        target.collider._getRadiusOnAxis(relativeVelocity));
+      function getCollidableRadius(collider) {
+        return collider instanceof p5.OrientedBoundingBoxCollider ? 0 : collider._getRadiusOnAxis(relativeVelocity);
+      }
+      var radiusOnVelocityAxis = Math.max(getCollidableRadius(this.collider), getCollidableRadius(target.collider));
       var timestep = Math.max(0.015, radiusOnVelocityAxis / Math.sqrt(squareVelocity));
       // If the objects are small enough to benefit from multisampling at this
       // relative velocity

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2313,10 +2313,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
       // We want to limit this so that we don't take an absurd number of samples
       // when objects end up at very high velocities (as happens sometimes in
       // game engines).
-      function getCollidableRadius(collider) {
-        return collider instanceof p5.OrientedBoundingBoxCollider ? 0 : collider._getRadiusOnAxis(relativeVelocity);
-      }
-      var radiusOnVelocityAxis = Math.max(getCollidableRadius(this.collider), getCollidableRadius(target.collider));
+      var radiusOnVelocityAxis = Math.max(
+        this.collider._getTunnelRadiusOnAxis(relativeVelocity),
+        target.collider._getTunnelRadiusOnAxis(relativeVelocity));
       var timestep = Math.max(0.015, radiusOnVelocityAxis / Math.sqrt(squareVelocity));
       // If the objects are small enough to benefit from multisampling at this
       // relative velocity
@@ -4320,6 +4319,17 @@ p5.prototype._warn = function(message) {
   };
 
   /**
+   * Get the shape's radius for tunneling checks along a given axis. For most
+   * colliders this is the same as `_getRadiusOnAxis`.
+   * @method _getTunnelRadiusOnAxis
+   * @protected
+   * @param {p5.Vector} axis
+   * @return {number}
+   */
+  p5.CollisionShape.prototype._getTunnelRadiusOnAxis =
+    p5.CollisionShape.prototype._getRadiusOnAxis;
+
+  /**
    * @property X_AXIS
    * @type {p5.Vector}
    * @static
@@ -5017,6 +5027,18 @@ p5.prototype._warn = function(message) {
     p5.AxisAlignedBoundingBoxCollider.prototype._getRadiusOnAxis;
   // We can reuse the AABB version of this method because both are projecting
   // cached half-diagonals - the same code works.
+
+  /**
+   * When checking for tunneling through a OrientedBoundingBoxCollider use a
+   * worst-case of zero (e.g. if the other sprite is passing through a corner).
+   * @method _getTunnelRadiusOnAxis
+   * @protected
+   * @param {p5.Vector} axis
+   * @return {number}
+   */
+  p5.OrientedBoundingBoxCollider.prototype._getTunnelRadiusOnAxis = function() {
+    return 0;
+  };
 
   /**
    * A 2D affine transformation (translation, rotation, scale) stored as a


### PR DESCRIPTION
We currently use a collider's on-axis radius to calculate the number of samples to check for tunneling.  For some OBB collisions the radius is much larger than the actual path of the other collider through the OBB:

<img width="226" alt="collidable-width" src="https://cloud.githubusercontent.com/assets/413693/20381100/c1b5bdea-ac5a-11e6-8f77-76c9dd74db01.png">

As a result we don't get enough samples to prevent tunneling even at low relative velocities:

![tunnel-test](https://cloud.githubusercontent.com/assets/413693/20380520/6d8e1134-ac57-11e6-83d7-9de3d837707c.gif)

It's difficult to calculate the tunnel width though an OBB because the width varies depending where it intersects the OBB.  It can as large as the on-axis radius or very small if the other collider hits near a corner:

![tunneling-corner](https://cloud.githubusercontent.com/assets/413693/20380681/5cfb8148-ac58-11e6-8fad-0d2dae319478.gif)

This PR calculates a sampling time step for OBBs based on the worst case of zero.  We'll end up oversampling when the other collider passes through the bulk of the OBB.  We might be able to improve this by finding the true tunnel radius for a given relative velocity vector.