### PR TITLE
Use swept colliders for a more precise broad-phase tunneling check

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1241,6 +1241,35 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.animation = undefined;
 
+  /**
+   * Swept collider oriented along the current velocity vector, extending to
+   * cover the old and new positions of the sprite.
+   *
+   * The corners of the swept collider will extend beyond the actual swept
+   * shape, but it should be sufficient for broad-phase detection of collision
+   * candidates.
+   *
+   * Note that this collider will have no dimensions if the source sprite has no
+   * velocity.
+   */
+  this._sweptCollider = new p5.OrientedBoundingBoxCollider();
+
+  /**
+   * If the sprite is moving, use the swept collider. Otherwise use the actual
+   * collider.
+   */
+  this._getBroadPhaseCollider = function() {
+    return (this.velocity.magSq() > 0) ? this._sweptCollider : this.collider;
+  };
+
+  /**
+   * Returns true if the two sprites crossed paths in the current frame,
+   * indicating a possible collision.
+   */
+  this._doSweptCollidersOverlap = function(target) {
+    return this._getBroadPhaseCollider().collide(target._getBroadPhaseCollider()).magSq() > 0;
+  };
+
   /*
    * @private
    * Keep animation properties in sync with how the animation changes.
@@ -1263,6 +1292,19 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
     if(!this.removed)
     {
+      if (this.collider) {
+        var vMagnitude = this.velocity.mag();
+        var vPerpendicular = createVector(this.velocity.y, -this.velocity.x);
+
+        this._sweptCollider.width = vMagnitude + 2 * this.collider._getRadiusOnAxis(this.velocity);
+        this._sweptCollider.height = 2 * this.collider._getRadiusOnAxis(vPerpendicular);
+        this._sweptCollider.rotation = radians(this.getDirection());
+        this._sweptCollider.center = createVector(
+          this.newPosition.x + 0.5 * this.velocity.x,
+          this.newPosition.y + 0.5 * this.velocity.y
+        );
+      }
+
       //if there has been a change somewhere after the last update
       //the old position is the last position registered in the update
       if(this.newPosition !== this.position)
@@ -2291,24 +2333,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
   this._findDisplacement = function(target) {
     // Multisample if tunneling occurs:
-    // If the direction between the two
-    // If the relative velocities of the two sprites is greater than the
-    // difference of their previous centers on the velocity axis,
-    // their centers might have crossed on an axis this frame which would permit
-    // tunneling.
+    // Do broad-phase detection. Check if the swept colliders overlap.
     // In that case, test interpolations between their last positions and their
     // current positions, and check for tunneling that way.
-    var relativeVelocity = p5.Vector.sub(this.velocity, target.velocity);
-    var squareVelocity = relativeVelocity.magSq();
-    var centerSquareDistanceOnVelocityAxis = p5.Vector.project(
-      p5.Vector.sub(this.collider.center, target.collider.center),
-      relativeVelocity
-    ).magSq();
-
-    // If the collider centers are closer on the velocity axis than the
-    // velocity itself, we are close enough to have tunneled this frame.
     // Use multisampling to catch collisions we might otherwise miss.
-    if (squareVelocity > centerSquareDistanceOnVelocityAxis) {
+    if (this._doSweptCollidersOverlap(target)) {
       // Figure out how many samples we should take.
       // We want to limit this so that we don't take an absurd number of samples
       // when objects end up at very high velocities (as happens sometimes in
@@ -2316,7 +2345,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
       var radiusOnVelocityAxis = Math.max(
         this.collider._getMinRadius(),
         target.collider._getMinRadius());
-      var timestep = Math.max(0.015, radiusOnVelocityAxis / Math.sqrt(squareVelocity));
+      var relativeVelocity = p5.Vector.sub(this.velocity, target.velocity).mag();
+      var timestep = Math.max(0.015, radiusOnVelocityAxis / relativeVelocity);
       // If the objects are small enough to benefit from multisampling at this
       // relative velocity
       if (timestep < 1) {

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1267,7 +1267,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
    * indicating a possible collision.
    */
   this._doSweptCollidersOverlap = function(target) {
-    return this._getBroadPhaseCollider().collide(target._getBroadPhaseCollider()).magSq() > 0;
+    var displacement = this._getBroadPhaseCollider().collide(target._getBroadPhaseCollider());
+    return displacement.x !== 0 || displacement.y !== 0;
   };
 
   /*


### PR DESCRIPTION
There are cases when the centers distance is larger than the relative velocity, but tunneling still may have occurred (e.g. when a small object passes through a thin object far from the center).

![before](https://cloud.githubusercontent.com/assets/413693/20576288/3b58ea20-b172-11e6-84cd-7c38a63cbe82.gif)
https://gist.github.com/joshlory/46f199786cd0a96597a88cc2f20aaa62

This PR creates a `_sweptCollider` oriented along each sprite's velocity vector, extending to cover the old and new positions of the sprite.  The corners of the swept collider will extend beyond the actual swept shape, but it should be sufficient for broad-phase detection of collision candidates.

<img width="398" alt="swept-collider" src="https://cloud.githubusercontent.com/assets/413693/20577573/cb6a4d66-b177-11e6-83e0-68d788cefe11.png">

When checking for tunneling, first check if the swept colliders overlap.  If they do, run the existing multisample interpolation to check if there really was a collision.

![after](https://cloud.githubusercontent.com/assets/413693/20577665/45d409a2-b178-11e6-96ff-afea635d80a7.gif)