### PR TITLE
Fix docs for animation.nextFrame/previousFrame

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3276,11 +3276,11 @@ function Animation(pInst) {
     //this.playing = false;
   };
 
-   /**
-  * Goes to the next frame and stops.
-  *
-  * @method changeFrame
-  */
+  /**
+   * Goes to the next frame and stops.
+   *
+   * @method nextFrame
+   */
   this.nextFrame = function() {
 
     if (frame<this.images.length-1)
@@ -3292,11 +3292,11 @@ function Animation(pInst) {
     this.playing = false;
   };
 
-   /**
-  * Goes to the next frame and stops.
-  *
-  * @method changeFrame
-  */
+  /**
+   * Goes to the previous frame and stops.
+   *
+   * @method previousFrame
+   */
   this.previousFrame = function() {
 
     if (frame>0)


### PR DESCRIPTION
These two methods weren't getting entries in the documentation because they had incorrect method names.  Fixing so we can regenerate our docs on github.io.