### PR TITLE
Bug fix - sprite re-scaled unexpectedly after setting collider

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1352,17 +1352,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       //animation is still loading
       return;
     }
-
-    //if has animation get the animation bounding box
-    //working only for preloaded images
-    if(animations[currentAnimation]) {
-      this._internalWidth = animations[currentAnimation].getWidth();
-      this._internalHeight = animations[currentAnimation].getHeight();
-      this.setCollider('rectangle');
-    } else {
-      this.setCollider('rectangle');
-    }
-
+    this.setCollider('rectangle');
     pInst.quadTree.insert(this);
   };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1356,8 +1356,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     //if has animation get the animation bounding box
     //working only for preloaded images
     if(animations[currentAnimation]) {
-      this._internalWidth = animations[currentAnimation].getWidth()*abs(this._getScaleX());
-      this._internalHeight = animations[currentAnimation].getHeight()*abs(this._getScaleY());
+      this._internalWidth = animations[currentAnimation].getWidth();
+      this._internalHeight = animations[currentAnimation].getHeight();
       this.setCollider('rectangle');
     } else {
       this.setCollider('rectangle');


### PR DESCRIPTION
Default collider shouldn't change internal width and height