### PR TITLE
Bug fix - Circle collider should scale with max of internal scale values

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4125,13 +4125,7 @@ p5.prototype._warn = function(message) {
    * @param {p5.Transform2D|Sprite} parent
    */
   p5.CollisionShape.prototype.setParentTransform = function(parent) {
-    if (parent instanceof Sprite && this instanceof p5.CircleCollider) {
-      this._parentTransform
-        .clear()
-        .scale(Math.max(parent._getScaleX(), parent._getScaleY()))
-        .rotate(radians(parent.rotation))
-        .translate(parent.position);
-    } else if (parent instanceof Sprite) {
+    if (parent instanceof Sprite) {
       this._parentTransform
         .clear()
         .scale(parent._getScaleX(), parent._getScaleY())
@@ -4521,6 +4515,32 @@ p5.prototype._warn = function(message) {
     sketch.rectMode(sketch.CENTER);
     sketch.ellipse(this.center.x, this.center.y, this._scaledRadius*2, this._scaledRadius*2);
     sketch.pop();
+  };
+
+    /**
+   * Overrides CollisionShape.setParentTransform
+   * Update this collider's parent transform, which will in turn adjust its
+   * position, rotation and scale in world-space and recompute cached values
+   * if necessary.
+   * If a Sprite is passed as the 'parent' then a new transform will be computed
+   * from the sprite's position/rotation/scale and used.
+   * Use the max of the x and y scales values so the circle encompasses the sprite.
+   * @method setParentTransform
+   * @param {p5.Transform2D|Sprite} parent
+   */
+  p5.CircleCollider.prototype.setParentTransform = function(parent) {
+    if (parent instanceof Sprite) {
+      this._parentTransform
+        .clear()
+        .scale(Math.max(parent._getScaleX(), parent._getScaleY()))
+        .rotate(radians(parent.rotation))
+        .translate(parent.position);
+    } else if (parent instanceof p5.Transform2D) {
+      this._parentTransform = parent.copy();
+    } else {
+      throw new TypeError('Bad argument to setParentTransform: ' + parent);
+    }
+    this._onTransformChanged();
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4125,7 +4125,13 @@ p5.prototype._warn = function(message) {
    * @param {p5.Transform2D|Sprite} parent
    */
   p5.CollisionShape.prototype.setParentTransform = function(parent) {
-    if (parent instanceof Sprite) {
+    if (parent instanceof Sprite && this instanceof p5.CircleCollider) {
+      this._parentTransform
+        .clear()
+        .scale(Math.max(parent._getScaleX(), parent._getScaleY()))
+        .rotate(radians(parent.rotation))
+        .translate(parent.position);
+    } else if (parent instanceof Sprite) {
       this._parentTransform
         .clear()
         .scale(parent._getScaleX(), parent._getScaleY())

--- a/test/unit/collision-circle.js
+++ b/test/unit/collision-circle.js
@@ -60,6 +60,45 @@ describe('CircleCollider', function() {
     // collider report correct radius on axis when scaleX != scaleY
   });
 
+  describe('setParentTransform', function() {
+    var circle, pInst;
+
+    beforeEach(function() {
+      circle = new p5.CircleCollider(new p5.Vector(), 5);
+      pInst = new p5(function() {});
+    });
+
+    afterEach(function() {
+      pInst.remove();
+    });
+
+    it('scales radius by height when height is greater', function() {
+      var parent = pInst.createSprite();
+      parent._getScaleX = function() {
+        return 2;
+      };
+      parent._getScaleY = function() {
+        return 3;
+      };
+      circle.setParentTransform(parent);
+      circle._computeScaledRadius();
+      expect(circle._scaledRadius).to.equal(15);
+    });
+
+    it('scales radius by width when width is greater', function() {
+      var parent = pInst.createSprite();
+      parent._getScaleX = function() {
+        return 4;
+      };
+      parent._getScaleY = function() {
+        return 3;
+      };
+      circle.setParentTransform(parent);
+      circle._computeScaledRadius();
+      expect(circle._scaledRadius).to.equal(20);
+    });
+  });
+
   describe('circles of same radii', function() {
     var a, b;
     beforeEach(function() {


### PR DESCRIPTION
We see this bug when setting the width and height of an animation and then using a circle collider: https://studio.code.org/projects/gamelab/_uEdJ7_utrKzer8nBggx7EA8sEiAaN2YA27ey0WcFJ8