### PR TITLE
Reduce swept collider work

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1294,16 +1294,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(!this.removed)
     {
       if (this.collider) {
-        var vMagnitude = this.velocity.mag();
-        var vPerpendicular = createVector(this.velocity.y, -this.velocity.x);
-
-        this._sweptCollider.width = vMagnitude + 2 * this.collider._getRadiusOnAxis(this.velocity);
-        this._sweptCollider.height = 2 * this.collider._getRadiusOnAxis(vPerpendicular);
-        this._sweptCollider.rotation = radians(this.getDirection());
-        this._sweptCollider.center = createVector(
-          this.newPosition.x + 0.5 * this.velocity.x,
-          this.newPosition.y + 0.5 * this.velocity.y
-        );
+        this._sweptCollider.updateSweptColliderFromSprite(this);
       }
 
       //if there has been a change somewhere after the last update
@@ -5015,6 +5006,34 @@ p5.prototype._warn = function(message) {
    */
   p5.OrientedBoundingBoxCollider.prototype.updateFromSprite =
     p5.AxisAlignedBoundingBoxCollider.prototype.updateFromSprite;
+
+  /**
+   * Assuming this collider is a sprite's swept collider, update it based on
+   * the properties of the parent sprite so that it encloses the sprite's
+   * current position and its projected position.
+   * @method updateSweptColliderFromSprite
+   * @param {Sprite} sprite
+   */
+  p5.OrientedBoundingBoxCollider.prototype.updateSweptColliderFromSprite = function(sprite) {
+    var vMagnitude = sprite.velocity.mag();
+    var vPerpendicular = new p5.Vector(sprite.velocity.y, -sprite.velocity.x);
+    this._width = vMagnitude + 2 * sprite.collider._getRadiusOnAxis(sprite.velocity);
+    this._height = 2 * sprite.collider._getRadiusOnAxis(vPerpendicular);
+    var newRotation = radians(sprite.getDirection());
+    var newCenter = new p5.Vector(
+      sprite.newPosition.x + 0.5 * sprite.velocity.x,
+      sprite.newPosition.y + 0.5 * sprite.velocity.y
+    );
+    // Perform this.rotation = newRotation and this.center = newCenter;
+    this._localTransform
+      .clear()
+      .scale(this._scale)
+      .rotate(newRotation)
+      .translate(this._offset)
+      .translate(p5.Vector.mult(this._center, -1))
+      .translate(newCenter);
+    this._onTransformChanged();
+  };
 
   /**
    * Recalculate cached properties, relevant vectors, etc. when at least one

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1293,7 +1293,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
     if(!this.removed)
     {
-      if (this._sweptCollider) {
+      if (this._sweptCollider && this.velocity.magSq() > 0) {
         this._sweptCollider.updateSweptColliderFromSprite(this);
       }
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1252,7 +1252,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
    * Note that this collider will have no dimensions if the source sprite has no
    * velocity.
    */
-  this._sweptCollider = new p5.OrientedBoundingBoxCollider();
+  this._sweptCollider = undefined;
 
   /**
    * If the sprite is moving, use the swept collider. Otherwise use the actual
@@ -1293,7 +1293,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
     if(!this.removed)
     {
-      if (this.collider) {
+      if (this._sweptCollider) {
         this._sweptCollider.updateSweptColliderFromSprite(this);
       }
 
@@ -1526,6 +1526,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     } else if (_type === 'obb') {
       this.collider = p5.OrientedBoundingBoxCollider.createFromSprite(this, offset, width, height, radians(rotation));
     }
+
+    this._sweptCollider = new p5.OrientedBoundingBoxCollider();
 
     // Disabled for Code.org, since perf seems better without the quadtree:
     // quadTree.insert(this);


### PR DESCRIPTION
Follow-up [to this discussion](https://github.com/code-dot-org/p5.play/pull/18/files#r89397262) noting that cached values on the swept collider were being recomputed multiple times during the sprite update.  Here, @caleybrock and I have made two small changes:

1. Create a helper method on `OrientedBoundingBoxCollider` to perform the swept collider update, so that cached values are recomputed only once.
   We believe this provides a small performance improvement when using swept colliders, and simplifies the sprite update code.
2. Lazy-create a swept collider on the sprite when we create a collider on the sprite, instead of creating one when the sprite is constructed.
   This should have little/no performance impact, but it's helpful to treat the collider/sweptCollider the same way since they are tightly bound.  In fact, I wonder if one should absorb the other at some point.  Alternatively, maybe we could be _lazier_ creating the swept collider and only create one if the sprite in question ever has a nonzero velocity.