### PR TITLE
Performance optimizations

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4389,10 +4389,10 @@ p5.prototype._warn = function(message) {
     var radiusOnX = this._getRadiusOnAxis(p5.CollisionShape.X_AXIS);
     var radiusOnY = this._getRadiusOnAxis(p5.CollisionShape.Y_AXIS);
     return {
-      top: this.center - radiusOnY,
-      bottom: this.center + radiusOnY,
-      left: this.center - radiusOnX,
-      right: this.center + radiusOnX,
+      top: this.center.y - radiusOnY,
+      bottom: this.center.y + radiusOnY,
+      left: this.center.x - radiusOnX,
+      right: this.center.x + radiusOnX,
       width: radiusOnX * 2,
       height: radiusOnY * 2
     };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1536,7 +1536,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
       this.collider = p5.OrientedBoundingBoxCollider.createFromSprite(this, offset, width, height, radians(rotation));
     }
 
-    quadTree.insert(this);
+    // Disabled for Code.org, since perf seems better without the quadtree:
+    // quadTree.insert(this);
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1396,7 +1396,6 @@ function Sprite(pInst, _x, _y, _w, _h) {
       return;
     }
     this.setCollider('rectangle');
-    pInst.quadTree.insert(this);
   };
 
   /**

--- a/test/unit/collision-shape.js
+++ b/test/unit/collision-shape.js
@@ -110,6 +110,17 @@ describe('CollisionShape interface', function() {
         expect(shape.scale.y).to.eq(3);
       });
 
+      it('can compute its bounding box', function() {
+        var shape = new ShapeType();
+        var bbox = shape.getBoundingBox();
+        expect(typeof bbox.top).to.eq('number');
+        expect(typeof bbox.bottom).to.eq('number');
+        expect(typeof bbox.left).to.eq('number');
+        expect(typeof bbox.right).to.eq('number');
+        expect(typeof bbox.width).to.eq('number');
+        expect(typeof bbox.height).to.eq('number');
+      });
+
       describe('parent transforms', function() {
         it('center represents global (combined) position, offset represents local', function() {
           var shape = new ShapeType(new p5.Vector(2, 3));


### PR DESCRIPTION
I found a couple of errors while debugging Game Lab startup time that provide small performance boosts when fixed.

In particular, I ran this test program (500 sprites, colliding with edges) and looked at the `setup()` time and the first couple of frames of `draw()` time, which have some unique characteristics.
```javascript
var sprite;
var group = createGroup();
for (var i = 0; i < 500; i++) {
  sprite = createSprite(
    randomNumber(50, 350),
    randomNumber(50, 350),
    20, 20);
  sprite.shapeColor = rgb(
    randomNumber(0, 200),
    randomNumber(0, 200),
    randomNumber(0, 200)
  );
  sprite.velocityX = randomNumber(-3, 3);
  sprite.velocityY = randomNumber(-3, 3);
  sprite.rotationSpeed = randomNumber(-1, 1);
  group.add(sprite);
}
createEdgeSprites();

function draw() {
  // group.bounce(group);
  group.bounceOff(edges);
  background('white');
  drawSprites();
}
```

I'll comment on the particular fixes inline.  I didn't profile these carefully, but there's an obvious improvement in first-frame time, possibly better than cutting it in half.