### PR TITLE
New YUIDoc settings for Code.org-specific docs

### DIFF
--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,8 +1,8 @@
 {
-    "name": "p5.play",
-    "description": "A  p5.js library for games and playthings",
-    "version": "1.0.0",
-    "url": "http://molleindustria.org/",
+    "name": "Code.org p5.play",
+    "description": "Code.org fork of the p5.js library for games and playthings",
+    "version": "1.1.9-cdo",
+    "url": "http://code-dot-org.github.io/p5-play",
     "logo":"../asterisk.png",
     "options": {
         "outdir": "docs",


### PR DESCRIPTION
Updates the settings used to generate our reference documentation on https://code-dot-org.github.io/p5.play to make the docs consistently point out that you're on the Code.org fork of p5.play, and not the docs for the original project.  (This should eventually affect how these pages show up in search results, too).  Related documentation changes have already been deployed.