### PR TITLE
1.2.0-cdo create colliders for debug sprites

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1639,6 +1639,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
         stroke(0, 255, 0);
 
         // Draw collision shape
+        if (this.collider === undefined) {
+          this.setDefaultCollider();
+        }
         if(this.collider) {
           this.collider.draw(pInst);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.1.9-cdo",
+  "version": "1.2.0-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
* For our new "Debug Sprites" button, we want to show collision rectangles for all debug sprites. The collision rectangles until now only appeared for sprites that had a collider set. Setting `debug = true` for a sprite without a collider set would have no effect. This change ensures that a default collider is set for any sprite with `debug` set at the time where the collider will be asked to `draw()`. The way in which we create the default collider looks exactly what happens when a sprite is referenced in `_collideWithOne()`