### PR TITLE
Optionally render sprites with a tint

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -790,6 +790,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var push = pInstBind('push');
   var pop = pInstBind('pop');
   var colorMode = pInstBind('colorMode');
+  var tint = pInstBind('tint');
+  var lerpColor = pInstBind('lerpColor');
   var noStroke = pInstBind('noStroke');
   var rectMode = pInstBind('rectMode');
   var ellipseMode = pInstBind('ellipseMode');
@@ -1666,13 +1668,25 @@ function Sprite(pInst, _x, _y, _w, _h) {
   {
     if(currentAnimation !== '' && animations)
     {
-      if(animations[currentAnimation])
+      if(animations[currentAnimation]) {
+        if(this.tint) {
+          push();
+          tint(this.tint);
+        }
         animations[currentAnimation].draw(0, 0, 0);
+        if(this.tint) {
+          pop();
+        }
+      }
     }
     else
     {
+      var fillColor = this.shapeColor;
+      if (this.tint) {
+        fillColor = lerpColor(color(fillColor), color(this.tint), 0.5);
+      }
       noStroke();
-      fill(this.shapeColor);
+      fill(fillColor);
       rect(0, 0, this._internalWidth, this._internalHeight);
     }
   };


### PR DESCRIPTION
Add support for a `tint` property on sprites, so that it's easy to have sprites with multiple colors using just one base animation.

![image](https://user-images.githubusercontent.com/1070243/38064108-3d5c494a-32b1-11e8-85ee-acb8f1d49e87.png)

Unfortunately p5's `tint` only applies to images, so I had to handle the basic shape color separately using `lerpColor`.