### PR TITLE
map touches to mouse state

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -192,6 +192,11 @@ defineLazyP5Property('allSprites', function() {
   return new p5.prototype.Group();
 });
 
+p5.prototype._mouseButtonIsPressed = function (buttonCode) {
+  return (this.mouseIsPressed && this.mouseButton === buttonCode) ||
+    (this.touchIsDown && buttonCode === this.LEFT);
+};
+
 p5.prototype.spriteUpdate = true;
 
 /**
@@ -513,7 +518,7 @@ p5.prototype._isMouseButtonInState = function(buttonCode, state) {
   //undefined = not tracked yet, start tracking
   if(mouseStates[buttonCode]===undefined)
   {
-  if(this.mouseIsPressed && this.mouseButton === buttonCode)
+  if (this._mouseButtonIsPressed(buttonCode))
     mouseStates[buttonCode] = KEY_IS_DOWN;
   else
     mouseStates[buttonCode] = KEY_IS_UP;
@@ -688,7 +693,7 @@ p5.prototype.readPresses = function() {
   //mouse
   for (var btn in mouseStates) {
 
-    if(this.mouseIsPressed && this.mouseButton === btn) //if is down
+    if(this._mouseButtonIsPressed(btn)) //if is down
     {
       if(mouseStates[btn] === KEY_IS_UP)//and was up
         mouseStates[btn] = KEY_WENT_DOWN;
@@ -1416,7 +1421,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       this.mouseIsOver = this.collider.overlap(new p5.PointCollider(mousePosition));
 
       //global p5 var
-      if(this.mouseIsOver && pInst.mouseIsPressed)
+      if(this.mouseIsOver && (pInst.mouseIsPressed || pInst.touchIsDown))
         this.mouseIsPressed = true;
 
       //event change - call functions

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -192,7 +192,7 @@ defineLazyP5Property('allSprites', function() {
   return new p5.prototype.Group();
 });
 
-p5.prototype._mouseButtonIsPressed = function (buttonCode) {
+p5.prototype._mouseButtonIsPressed = function(buttonCode) {
   return (this.mouseIsPressed && this.mouseButton === buttonCode) ||
     (this.touchIsDown && buttonCode === this.LEFT);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.2.1-cdo",
+  "version": "1.2.2-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
* Ensure `mouseStates` for the `LEFT` button are set in response to touches (already tracked via p5's `touchIsDown` property)
  * Use new `_mouseButtonIsPressed()` helper when checking the mouse state
* Ensure that `Sprite. mouseIsPressed` property is updated properly in response to touches (this property requires that `Sprite.mouseActive` be set to `true`)

End result: `mouseDown()`, `mouseUp()`, `mouseWentDown()`, `mouseWentUp()` now work as expected on mobile devices