### PR TITLE
Code.org p5.play extensions part 1

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2448,6 +2448,38 @@ function Camera(pInst, x, y, zoom) {
   this.position = pInst.createVector(x, y);
 
   /**
+  * Camera x position. Defines the horizontal global offset of the sketch.
+  *
+  * @property x
+  * @type {Number}
+  */
+ Object.defineProperty(this, 'x', {
+    enumerable: true,
+    get: function () {
+      return this.position.x;
+    },
+    set: function (value) {
+      this.position.x = value;
+    }
+  });
+
+  /**
+  * Camera y position. Defines the horizontal global offset of the sketch.
+  *
+  * @property y
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'y', {
+    enumerable: true,
+    get: function () {
+      return this.position.y;
+    },
+    set: function (value) {
+      this.position.y = value;
+    }
+  });
+
+  /**
   * Camera zoom. Defines the global scale of the sketch.
   * A scale of 1 will be the normal size. Setting it to 2 will make everything
   * twice the size. .5 will make everything half size.
@@ -2488,6 +2520,18 @@ function Camera(pInst, x, y, zoom) {
   * @type {Boolean}
   */
   this.active = false;
+
+  /**
+  * Check to see if the camera is active.
+  * Use the methods Camera.on() and Camera.off()
+  * to enable or disable the camera.
+  *
+  * @method isActive
+  * @return {Boolean} true if the camera is active
+  */
+  this.isActive = function() {
+    return this.active;
+  }
 
   /**
   * Activates the camera.

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -717,7 +717,8 @@ p5.prototype.readPresses = function() {
 * It can improve performance when there is a large number of Sprites to be
 * checked continuously for overlapping.
 *
-* p5.play will create and update a quadtree automatically.
+* p5.play will create and update a quadtree automatically, however it is
+* inactive by default.
 *
 * @method useQuadTree
 * @param {Boolean} use Pass true to enable, false to disable
@@ -739,12 +740,14 @@ p5.prototype.useQuadTree = function(use) {
 
 //the actual quadTree
 defineLazyP5Property('quadTree', function() {
-  return new Quadtree({
+  var quadTree = new Quadtree({
     x: 0,
     y: 0,
     width: 0,
     height: 0
   }, 4);
+  quadTree.active = false;
+  return quadTree;
 });
 
 /*

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2468,10 +2468,10 @@ function Camera(pInst, x, y, zoom) {
   */
  Object.defineProperty(this, 'x', {
     enumerable: true,
-    get: function () {
+    get: function() {
       return this.position.x;
     },
-    set: function (value) {
+    set: function(value) {
       this.position.x = value;
     }
   });
@@ -2484,10 +2484,10 @@ function Camera(pInst, x, y, zoom) {
   */
   Object.defineProperty(this, 'y', {
     enumerable: true,
-    get: function () {
+    get: function() {
       return this.position.y;
     },
-    set: function (value) {
+    set: function(value) {
       this.position.y = value;
     }
   });
@@ -2544,7 +2544,7 @@ function Camera(pInst, x, y, zoom) {
   */
   this.isActive = function() {
     return this.active;
-  }
+  };
 
   /**
   * Activates the camera.

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -35,6 +35,8 @@ factory(root.p5);
 //                         initialization
 // =============================================================================
 
+const DEFAULT_FRAME_RATE = 30;
+
 // This is the new way to initialize custom p5 properties for any p5 instance.
 // The goal is to migrate lazy P5 properties over to this method.
 // @see https://github.com/molleindustria/p5.play/issues/46
@@ -54,6 +56,14 @@ p5.prototype.registerMethod('init', function p5PlayInit() {
    */
   this.camera = new Camera(this, 0, 0, 1);
   this.camera.init = false;
+
+  this.angleMode(this.DEGREES);
+  this.frameRate(DEFAULT_FRAME_RATE);
+
+  this._defaultCanvasSize = {
+    width: 400,
+    height: 400
+  };
 });
 
 // This provides a way for us to lazily define properties that

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -35,7 +35,7 @@ factory(root.p5);
 //                         initialization
 // =============================================================================
 
-const DEFAULT_FRAME_RATE = 30;
+var DEFAULT_FRAME_RATE = 30;
 
 // This is the new way to initialize custom p5 properties for any p5 instance.
 // The goal is to migrate lazy P5 properties over to this method.


### PR DESCRIPTION
This is part 1 of a series of changes to migrate our monkey-patched Code.org p5.play changes into our fork of p5.play, in preparation for source code compatibility when exporting Gamelab projects.
The following seven changes are included in this PR:

1. Add `isActive()` method to `Camera`
1. Add `x` property to `Camera`
1. Add `y` property to `Camera`
1. Start with inactive `quadTree`
1. Default `frameRate` to `30`
1. Default `angleMode` to `DEGREES`
1. Default canvas size to `400` x `400`

These changes will allow us to remove 7 similar changes from `GameLabP5.js` in the `code-dot-org` repo.
