### PR TITLE
Code.org p5.play extensions part 2

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -258,8 +258,8 @@ function getTouchInfo(canvas, e, i) {
   var yPos = touch.clientY - rect.top;
   if (xPos >= 0 && xPos < rect.width && yPos >= 0 && yPos < rect.height) {
     return {
-      x: Math.round(xPos / 1), // self.scale), // TODO: determine CSS transform scale
-      y: Math.round(yPos / 1), // self.scale),
+      x: Math.round(xPos * canvas.offsetWidth / rect.width),
+      y: Math.round(yPos * canvas.offsetHeight / rect.height),
       id: touch.identifier
     };
   }
@@ -333,8 +333,8 @@ function getMousePos(canvas, evt) {
   var yPos = evt.clientY - rect.top;
   if (xPos >= 0 && xPos < rect.width && yPos >= 0 && yPos < rect.height) {
     return {
-      x: Math.round(xPos / 1), // self.scale), // TODO: determine CSS transform scale
-      y: Math.round(yPos / 1), // self.scale)
+      x: Math.round(xPos * canvas.offsetWidth / rect.width),
+      y: Math.round(yPos * canvas.offsetHeight / rect.height)
     };
   }
 }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -145,6 +145,201 @@ var radians = p5.prototype.radians;
 var degrees = p5.prototype.degrees;
 
 // =============================================================================
+//                         p5 overrides
+// =============================================================================
+
+// Make width and height optional for ellipse() - default to 50
+// Save the original implementation to allow for optional parameters.
+if (!p5.prototype.originalEllipse_) {
+  p5.prototype.originalEllipse_ = p5.prototype.ellipse;
+  p5.prototype.ellipse = function(x, y, w, h) {
+    w = (w) ? w : 50;
+    h = (w && !h) ? w : h;
+    this.originalEllipse_(x, y, w, h);
+  };
+}
+
+// Make width and height optional for rect() - default to 50
+// Save the original implementation to allow for optional parameters.
+if (!p5.prototype.originalRect_) {
+  p5.prototype.originalRect_ = p5.prototype.rect;
+  p5.prototype.rect = function(x, y, w, h) {
+    w = (w) ? w : 50;
+    h = (w && !h) ? w : h;
+    this.originalRect_(x, y, w, h);
+  };
+}
+
+// Modify p5 to ignore out-of-bounds positions before setting touchIsDown
+p5.prototype._ontouchstart = function(e) {
+  if (!this._curElement) {
+    return;
+  }
+  var validTouch;
+  for (var i = 0; i < e.touches.length; i++) {
+    validTouch = getTouchInfo(this._curElement.elt, e, i);
+    if (validTouch) {
+      break;
+    }
+  }
+  if (!validTouch) {
+    // No in-bounds (valid) touches, return and ignore:
+    return;
+  }
+  var context = this._isGlobal ? window : this;
+  var executeDefault;
+  this._updateNextTouchCoords(e);
+  this._updateNextMouseCoords(e);
+  this._setProperty('touchIsDown', true);
+  if (typeof context.touchStarted === 'function') {
+    executeDefault = context.touchStarted(e);
+    if (executeDefault === false) {
+      e.preventDefault();
+    }
+  } else if (typeof context.mousePressed === 'function') {
+    executeDefault = context.mousePressed(e);
+    if (executeDefault === false) {
+      e.preventDefault();
+    }
+    //this._setMouseButton(e);
+  }
+};
+
+// Modify p5 to handle CSS transforms (scale) and ignore out-of-bounds
+// positions before reporting touch coordinates
+//
+// NOTE: _updateNextTouchCoords() is nearly identical, but calls a modified
+// getTouchInfo() function below that scales the touch postion with the play
+// space and can return undefined
+p5.prototype._updateNextTouchCoords = function(e) {
+  var x = this.touchX;
+  var y = this.touchY;
+  if (e.type === 'mousedown' || e.type === 'mousemove' ||
+      e.type === 'mouseup' || !e.touches) {
+    x = this.mouseX;
+    y = this.mouseY;
+  } else {
+    if (this._curElement !== null) {
+      var touchInfo = getTouchInfo(this._curElement.elt, e, 0);
+      if (touchInfo) {
+        x = touchInfo.x;
+        y = touchInfo.y;
+      }
+
+      var touches = [];
+      var touchIndex = 0;
+      for (var i = 0; i < e.touches.length; i++) {
+        // Only some touches are valid - only push valid touches into the
+        // array for the `touches` property.
+        touchInfo = getTouchInfo(this._curElement.elt, e, i);
+        if (touchInfo) {
+          touches[touchIndex] = touchInfo;
+          touchIndex++;
+        }
+      }
+      this._setProperty('touches', touches);
+    }
+  }
+  this._setProperty('touchX', x);
+  this._setProperty('touchY', y);
+  if (!this._hasTouchInteracted) {
+    // For first draw, make previous and next equal
+    this._updateTouchCoords();
+    this._setProperty('_hasTouchInteracted', true);
+  }
+};
+
+// NOTE: returns undefined if the position is outside of the valid range
+function getTouchInfo(canvas, e, i) {
+  i = i || 0;
+  var rect = canvas.getBoundingClientRect();
+  var touch = e.touches[i] || e.changedTouches[i];
+  var xPos = touch.clientX - rect.left;
+  var yPos = touch.clientY - rect.top;
+  if (xPos >= 0 && xPos < rect.width && yPos >= 0 && yPos < rect.height) {
+    return {
+      x: Math.round(xPos / 1), // self.scale), // TODO: determine CSS transform scale
+      y: Math.round(yPos / 1), // self.scale),
+      id: touch.identifier
+    };
+  }
+}
+
+// Modify p5 to ignore out-of-bounds positions before setting mouseIsPressed
+// and isMousePressed
+p5.prototype._onmousedown = function(e) {
+  if (!this._curElement) {
+    return;
+  }
+  if (!getMousePos(this._curElement.elt, e)) {
+    // Not in-bounds, return and ignore:
+    return;
+  }
+  var context = this._isGlobal ? window : this;
+  var executeDefault;
+  this._setProperty('isMousePressed', true);
+  this._setProperty('mouseIsPressed', true);
+  this._setMouseButton(e);
+  this._updateNextMouseCoords(e);
+  this._updateNextTouchCoords(e);
+  if (typeof context.mousePressed === 'function') {
+    executeDefault = context.mousePressed(e);
+    if (executeDefault === false) {
+      e.preventDefault();
+    }
+  } else if (typeof context.touchStarted === 'function') {
+    executeDefault = context.touchStarted(e);
+    if (executeDefault === false) {
+      e.preventDefault();
+    }
+  }
+};
+
+// Modify p5 to handle CSS transforms (scale) and ignore out-of-bounds
+// positions before reporting mouse coordinates
+//
+// NOTE: _updateNextMouseCoords() is nearly identical, but calls a modified
+// getMousePos() function below that scales the mouse position with the play
+// space and can return undefined.
+p5.prototype._updateNextMouseCoords = function(e) {
+  var x = this.mouseX;
+  var y = this.mouseY;
+  if (e.type === 'touchstart' || e.type === 'touchmove' ||
+      e.type === 'touchend' || e.touches) {
+    x = this.touchX;
+    y = this.touchY;
+  } else if (this._curElement !== null) {
+    var mousePos = getMousePos(this._curElement.elt, e);
+    if (mousePos) {
+      x = mousePos.x;
+      y = mousePos.y;
+    }
+  }
+  this._setProperty('mouseX', x);
+  this._setProperty('mouseY', y);
+  this._setProperty('winMouseX', e.pageX);
+  this._setProperty('winMouseY', e.pageY);
+  if (!this._hasMouseInteracted) {
+    // For first draw, make previous and next equal
+    this._updateMouseCoords();
+    this._setProperty('_hasMouseInteracted', true);
+  }
+};
+
+// NOTE: returns undefined if the position is outside of the valid range
+function getMousePos(canvas, evt) {
+  var rect = canvas.getBoundingClientRect();
+  var xPos = evt.clientX - rect.left;
+  var yPos = evt.clientY - rect.top;
+  if (xPos >= 0 && xPos < rect.width && yPos >= 0 && yPos < rect.height) {
+    return {
+      x: Math.round(xPos / 1), // self.scale), // TODO: determine CSS transform scale
+      y: Math.round(yPos / 1), // self.scale)
+    };
+  }
+}
+
+// =============================================================================
 //                         p5 extensions
 // TODO: It'd be nice to get these accepted upstream in p5
 // =============================================================================
@@ -205,6 +400,161 @@ defineLazyP5Property('allSprites', function() {
 p5.prototype._mouseButtonIsPressed = function(buttonCode) {
   return (this.mouseIsPressed && this.mouseButton === buttonCode) ||
     (this.touchIsDown && buttonCode === this.LEFT);
+};
+
+p5.prototype.mouseDidMove = function() {
+  return this.pmouseX !== this.mouseX || this.pmouseY !== this.mouseY;
+};
+
+p5.prototype.mouseIsOver = function(sprite) {
+  if (!sprite) {
+    return false;
+  }
+
+  if (!sprite.collider) {
+    sprite.setDefaultCollider();
+  }
+
+  var mousePosition;
+  if (this.camera.active) {
+    mousePosition = this.createVector(this.camera.mouseX, this.camera.mouseY);
+  } else {
+    mousePosition = this.createVector(this.mouseX, this.mouseY);
+  }
+
+  return sprite.collider.overlap(new window.p5.PointCollider(mousePosition));
+};
+
+p5.prototype.mousePressedOver = function(sprite) {
+  return (this.mouseIsPressed || this.touchIsDown) && this.mouseIsOver(sprite);
+};
+
+var styleEmpty = 'rgba(0,0,0,0)';
+
+p5.Renderer2D.prototype.regularPolygon = function(x, y, sides, size, rotation) {
+  var ctx = this.drawingContext;
+  var doFill = this._doFill, doStroke = this._doStroke;
+  if (doFill && !doStroke) {
+    if (ctx.fillStyle === styleEmpty) {
+      return this;
+    }
+  } else if (!doFill && doStroke) {
+    if (ctx.strokeStyle === styleEmpty) {
+      return this;
+    }
+  }
+  if (sides < 3) {
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(x + size * Math.cos(rotation), y + size * Math.sin(rotation));
+  for (var i = 1; i < sides; i++) {
+    var angle = rotation + (i * 2 * Math.PI / sides);
+    ctx.lineTo(x + size * Math.cos(angle), y + size * Math.sin(angle));
+  }
+  ctx.closePath();
+  if (doFill) {
+    ctx.fill();
+  }
+  if (doStroke) {
+    ctx.stroke();
+  }
+};
+
+p5.prototype.regularPolygon = function(x, y, sides, size, rotation) {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
+    return this;
+  }
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
+
+  if (typeof rotation === 'undefined') {
+    rotation = -(Math.PI / 2);
+    if (0 === sides % 2) {
+      rotation += Math.PI / sides;
+    }
+  } else if (this._angleMode === this.DEGREES) {
+    rotation = this.radians(rotation);
+  }
+
+  // NOTE: only implemented for non-3D
+  if (!this._renderer.isP3D) {
+    this._validateParameters(
+      'regularPolygon',
+      args,
+      [
+        ['Number', 'Number', 'Number', 'Number'],
+        ['Number', 'Number', 'Number', 'Number', 'Number']
+      ]
+    );
+    this._renderer.regularPolygon(
+      args[0],
+      args[1],
+      args[2],
+      args[3],
+      rotation
+    );
+  }
+  return this;
+};
+
+p5.Renderer2D.prototype.shape = function() {
+  var ctx = this.drawingContext;
+  var doFill = this._doFill, doStroke = this._doStroke;
+  if (doFill && !doStroke) {
+    if (ctx.fillStyle === styleEmpty) {
+      return this;
+    }
+  } else if (!doFill && doStroke) {
+    if (ctx.strokeStyle === styleEmpty) {
+      return this;
+    }
+  }
+  var numCoords = arguments.length / 2;
+  if (numCoords < 1) {
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(arguments[0], arguments[1]);
+  for (var i = 1; i < numCoords; i++) {
+    ctx.lineTo(arguments[i * 2], arguments[i * 2 + 1]);
+  }
+  ctx.closePath();
+  if (doFill) {
+    ctx.fill();
+  }
+  if (doStroke) {
+    ctx.stroke();
+  }
+};
+
+p5.prototype.shape = function() {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
+    return this;
+  }
+  // NOTE: only implemented for non-3D
+  if (!this._renderer.isP3D) {
+    // TODO: call this._validateParameters, once it is working in p5.js and
+    // we understand if it can be used for var args functions like this
+    this._renderer.shape.apply(this._renderer, arguments);
+  }
+  return this;
+};
+
+p5.prototype.rgb = function(r, g, b, a) {
+  // convert a from 0 to 255 to 0 to 1
+  if (!a) {
+    a = 1;
+  }
+  a = a * 255;
+
+  return this.color(r, g, b, a);
+};
+
+p5.prototype.createGroup = function() {
+  return new this.Group();
 };
 
 p5.prototype.spriteUpdate = true;


### PR DESCRIPTION
Building upon https://github.com/code-dot-org/p5.play/pull/31, here is part 2:
* rect(), ellipse() height and width params are now optional
* ignore out of bounds positions for touch and mouse events
* account for CSS transform scale
* add mouseDidMove(), mouseIsOver(sprite), mousePressedOver(sprite)
* add regularPolygon(), shape()
* add rgb(), createGroup()