### PR TITLE
Code.org p5.play extensions part 3

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1470,7 +1470,6 @@ function Sprite(pInst, _x, _y, _w, _h) {
    */
   this._horizontalStretch = 1;
 
-  // TODO p5-sync
   /*
    * @type {number}
    * @private
@@ -2245,6 +2244,13 @@ function Sprite(pInst, _x, _y, _w, _h) {
   };
 
   /**
+   * Alias for <a href='#method-remove'>remove()</a>
+   *
+   * @method destroy
+   */
+  this.destroy = this.remove;
+
+  /**
   * Sets the velocity vector.
   *
   * @method setVelocity
@@ -2355,6 +2361,108 @@ function Sprite(pInst, _x, _y, _w, _h) {
     }
     this.velocity.x = cos(a)*speed;
     this.velocity.y = sin(a)*speed;
+  };
+
+  /**
+   * Alias for <a href='#method-setSpeed'>setSpeed()</a>
+   *
+   * @method setSpeedAndDirection
+   */
+  this.setSpeedAndDirection = this.setSpeed;
+
+  /**
+  * Alias for <a href='Animation.html#method-changeFrame'>animation.changeFrame()</a>
+  *
+  * @method setFrame
+  * @param {Number} frame Frame number (starts from 0).
+  */
+  this.setFrame = function(f) {
+    if (this.animation) {
+      this.animation.changeFrame(f);
+    }
+  };
+
+  /**
+  * Alias for <a href='Animation.html#method-nextFrame'>animation.nextFrame()</a>
+  *
+  * @method nextFrame
+  */
+  this.nextFrame = function() {
+    if (this.animation) {
+      this.animation.nextFrame();
+    }
+  };
+
+  /**
+  * Alias for <a href='Animation.html#method-previousFrame'>animation.previousFrame()</a>
+  *
+  * @method previousFrame
+  */
+  this.previousFrame = function() {
+    if (this.animation) {
+      this.animation.previousFrame();
+    }
+  };
+
+  /**
+  * Alias for <a href='Animation.html#method-stop'>animation.stop()</a>
+  *
+  * @method pause
+  */
+  this.pause = function() {
+    if (this.animation) {
+      this.animation.stop();
+    }
+  };
+
+  /**
+   * Alias for <a href='Animation.html#method-play'>animation.play()</a> with extra logic
+   *
+   * Plays/resumes the sprite's current animation.
+   * If the animation is currently playing this has no effect.
+   * If the animation has stopped at its last frame, this will start it over
+   * at the beginning.
+   *
+   * @method play
+   */
+  this.play = function() {
+    if (!this.animation) {
+      return;
+    }
+    // Normally this just sets the 'playing' flag without changing the animation
+    // frame, which will cause the animation to continue on the next update().
+    // If the animation is non-looping and is stopped at the last frame
+    // we also rewind the animation to the beginning.
+    if (!this.animation.looping && !this.animation.playing && this.animation.getFrame() === this.animation.images.length - 1) {
+      this.animation.rewind();
+    }
+    this.animation.play();
+  };
+
+  /**
+   * Wrapper to access <a href='Animation.html#prop-frameChanged'>animation.frameChanged</a>
+   *
+   * @method frameDidChange
+   * @return {Boolean} true if the animation frame has changed
+   */
+  this.frameDidChange = function() {
+    return this.animation ? this.animation.frameChanged : false;
+  };
+
+  /**
+  * Rotate the sprite towards a specific position
+  *
+  * @method setFrame
+  * @param {Number} x Horizontal coordinate to point to
+  * @param {Number} y Vertical coordinate to point to
+  */
+  this.pointTo = function(x, y) {
+    var yDelta = y - this.position.y;
+    var xDelta = x - this.position.x;
+    if (!isNaN(xDelta) && !isNaN(yDelta) && (xDelta !== 0 || yDelta !== 0)) {
+      var radiansAngle = Math.atan2(yDelta, xDelta);
+      this.rotation = 360 * radiansAngle / (2 * Math.PI);
+    }
   };
 
   /**
@@ -2622,9 +2730,20 @@ function Sprite(pInst, _x, _y, _w, _h) {
   };
 
   /**
+   * Alias for <a href='#method-overlap'>overlap()</a>
+   *
+   * Returns whether or not this sprite will bounce or collide with another sprite
+   * or group. Modifies the sprite's touching property object.
+   *
+   * @method isTouching
+   * @param {Object} target Sprite or group to check against the current one
+   */
+  this.isTouching = this.overlap;
+
+  /**
   * Checks if the the sprite is overlapping another sprite or a group.
-  * If the overlap is positive the current sprite will be displace by
-  * the colliding one in the closest non-overlapping position.
+  * If the overlap is positive the sprite will bounce with the target(s)
+  * treated as immovable with a restitution coefficient of zero.
   *
   * The check is performed using the colliders. If colliders are not set
   * they will be created automatically from the image/animation bounding box.
@@ -2715,6 +2834,37 @@ function Sprite(pInst, _x, _y, _w, _h) {
   };
 
   /**
+  * Checks if the the sprite is overlapping another sprite or a group.
+  * If the overlap is positive the sprite will bounce with the target(s)
+  * treated as immovable.
+  *
+  * The check is performed using the colliders. If colliders are not set
+  * they will be created automatically from the image/animation bounding box.
+  *
+  * A callback function can be specified to perform additional operations
+  * when the collision occours.
+  * If the target is a group the function will be called for each single
+  * sprite colliding. The parameter of the function are respectively the
+  * current sprite and the colliding sprite.
+  *
+  * @example
+  *     sprite.bounceOff(otherSprite, explosion);
+  *
+  *     function explosion(spriteA, spriteB) {
+  *       spriteA.remove();
+  *       spriteB.score++;
+  *     }
+  *
+  * @method bounceOff
+  * @param {Object} target Sprite or group to check against the current one
+  * @param {Function} [callback] The function to be called if overlap is positive
+  * @return {Boolean} True if overlapping
+  */
+  this.bounceOff = function(target, callback) {
+    return this._collideWith('bounceOff', target, callback);
+  };
+
+  /**
    * Internal collision detection function. Do not use directly.
    *
    * Handles collision with individual sprites or with groups, using the
@@ -2722,7 +2872,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
    *
    * @method _collideWith
    * @private
-   * @param {string} type - 'overlap', 'displace', 'collide' or 'bounce'
+   * @param {string} type - 'overlap', 'displace', 'collide', 'bounce' or 'bounceOff'
    * @param {Sprite|Group} target
    * @param {function} callback - if collision occurred
    * @return {boolean} true if a collision occurred
@@ -2771,7 +2921,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
    *
    * @method _collideWithOne
    * @private
-   * @param {string} type - 'overlap', 'displace', 'collide' or 'bounce'
+   * @param {string} type - 'overlap', 'displace', 'collide', 'bounce' or 'bounceOff'
    * @param {Sprite} other
    * @param {function} callback - if collision occurred
    * @return {boolean} true if a collision occurred
@@ -2804,65 +2954,87 @@ function Sprite(pInst, _x, _y, _w, _h) {
       return false;
     }
 
-    if (type === 'collide' || type === 'displace' || type === 'bounce') {
-      if (type === 'displace' && !other.immovable) {
-        other.position.sub(displacement);
-      } else if ((type === 'collide' || type === 'bounce') && !this.immovable) {
-        this.position.add(displacement);
-        this.previousPosition = createVector(this.position.x, this.position.y);
-        this.newPosition = createVector(this.position.x, this.position.y);
-        this.collider.updateFromSprite(this);
-      }
+    if (displacement.x > 0)
+      this.touching.left = true;
+    if (displacement.x < 0)
+      this.touching.right = true;
+    if (displacement.y < 0)
+      this.touching.bottom = true;
+    if (displacement.y > 0)
+      this.touching.top = true;
 
-      if (displacement.x > 0)
-        this.touching.left = true;
-      if (displacement.x < 0)
-        this.touching.right = true;
-      if (displacement.y < 0)
-        this.touching.bottom = true;
-      if (displacement.y > 0)
-        this.touching.top = true;
-
-      // If this is a 'bounce' collision, determine the new velocities for each sprite
-      if (type === 'bounce') {
-        // We are concerned only with velocities parallel to the collision normal,
-        // so project our sprite velocities onto that normal (captured in the
-        // displacement vector) and use these throughout the calculation
-        var thisInitialVelocity = p5.Vector.project(this.velocity, displacement);
-        var otherInitialVelocity = p5.Vector.project(other.velocity, displacement);
-
-        // We only care about relative mass values, so if one of the sprites
-        // is considered 'immovable' treat the _other_ sprite's mass as zero
-        // to get the correct results.
-        var thisMass = this.mass;
-        var otherMass = other.mass;
-        if (this.immovable) {
-          thisMass = 1;
-          otherMass = 0;
-        } else if (other.immovable) {
-          thisMass = 0;
-          otherMass = 1;
-        }
-
-        var combinedMass = thisMass + otherMass;
-        var coefficientOfRestitution = this.restitution * other.restitution;
-        var initialMomentum = p5.Vector.add(
-          p5.Vector.mult(thisInitialVelocity, thisMass),
-          p5.Vector.mult(otherInitialVelocity, otherMass)
-        );
-        var thisFinalVelocity = p5.Vector.sub(otherInitialVelocity, thisInitialVelocity)
-          .mult(otherMass * coefficientOfRestitution)
-          .add(initialMomentum)
-          .div(combinedMass);
-        var otherFinalVelocity = p5.Vector.sub(thisInitialVelocity, otherInitialVelocity)
-          .mult(thisMass * coefficientOfRestitution)
-          .add(initialMomentum)
-          .div(combinedMass);
-        // Remove velocity before and apply velocity after to both members.
-        this.velocity.sub(thisInitialVelocity).add(thisFinalVelocity);
-        other.velocity.sub(otherInitialVelocity).add(otherFinalVelocity);
-      }
+    // Apply displacement out of collision
+    if (type === 'displace' && !other.immovable) {
+      other.position.sub(displacement);
+    } else if ((type === 'collide' || type === 'bounce' || type === 'bounceOff') && !this.immovable) {
+      this.position.add(displacement);
+      this.previousPosition = createVector(this.position.x, this.position.y);
+      this.newPosition = createVector(this.position.x, this.position.y);
+      this.collider.updateFromSprite(this);
     }
+
+    // Create special behaviors for certain collision types by temporarily
+    // overriding type and sprite properties.
+    // See another block near the end of this method that puts them back.
+    var originalType = type;
+    var originalThisImmovable = this.immovable;
+    var originalOtherImmovable = other.immovable;
+    var originalOtherRestitution = other.restitution;
+    if (originalType === 'collide') {
+      type = 'bounce';
+      other.immovable = true;
+      other.restitution = 0;
+    } else if (originalType === 'bounceOff') {
+      type = 'bounce';
+      other.immovable = true;
+    }
+
+    // If this is a 'bounce' collision, determine the new velocities for each sprite
+    if (type === 'bounce') {
+      // We are concerned only with velocities parallel to the collision normal,
+      // so project our sprite velocities onto that normal (captured in the
+      // displacement vector) and use these throughout the calculation
+      var thisInitialVelocity = p5.Vector.project(this.velocity, displacement);
+      var otherInitialVelocity = p5.Vector.project(other.velocity, displacement);
+
+      // We only care about relative mass values, so if one of the sprites
+      // is considered 'immovable' treat the _other_ sprite's mass as zero
+      // to get the correct results.
+      var thisMass = this.mass;
+      var otherMass = other.mass;
+      if (this.immovable) {
+        thisMass = 1;
+        otherMass = 0;
+      } else if (other.immovable) {
+        thisMass = 0;
+        otherMass = 1;
+      }
+
+      var combinedMass = thisMass + otherMass;
+      var coefficientOfRestitution = this.restitution * other.restitution;
+      var initialMomentum = p5.Vector.add(
+        p5.Vector.mult(thisInitialVelocity, thisMass),
+        p5.Vector.mult(otherInitialVelocity, otherMass)
+      );
+      var thisFinalVelocity = p5.Vector.sub(otherInitialVelocity, thisInitialVelocity)
+        .mult(otherMass * coefficientOfRestitution)
+        .add(initialMomentum)
+        .div(combinedMass);
+      var otherFinalVelocity = p5.Vector.sub(thisInitialVelocity, otherInitialVelocity)
+        .mult(thisMass * coefficientOfRestitution)
+        .add(initialMomentum)
+        .div(combinedMass);
+      // Remove velocity before and apply velocity after to both members.
+      this.velocity.sub(thisInitialVelocity).add(thisFinalVelocity);
+      other.velocity.sub(otherInitialVelocity).add(otherFinalVelocity);
+    }
+
+    // Restore sprite properties now that velocity changes have been made.
+    // See another block before velocity changes that sets these up.
+    type = originalType;
+    this.immovable = originalThisImmovable;
+    other.immovable = originalOtherImmovable;
+    other.restitution = originalOtherRestitution;
 
     // Finally, for all collision types call the callback and record
     // that collision occurred.
@@ -3354,7 +3526,7 @@ function Group() {
    *
    * @private
    * @method _groupCollide
-   * @param {!string} type one of 'overlap', 'collide', 'displace', 'bounce'
+   * @param {!string} type one of 'overlap', 'collide', 'displace', 'bounce' or 'bounceOff'
    * @param {Object} target Group or Sprite
    * @param {Function} [callback] on collision.
    * @return {boolean} True if any collision/overlap occurred

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1153,7 +1153,6 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
   var createVector = pInstBind('createVector');
   var color = pInstBind('color');
-  var random = pInstBind('random');
   var print = pInstBind('print');
   var push = pInstBind('push');
   var pop = pInstBind('pop');
@@ -1465,6 +1464,21 @@ function Sprite(pInst, _x, _y, _w, _h) {
   this._internalHeight = _h;
 
   /*
+   * @type {number}
+   * @private
+   * _horizontalStretch is the value to scale animation sprites in the X direction
+   */
+  this._horizontalStretch = 1;
+
+  // TODO p5-sync
+  /*
+   * @type {number}
+   * @private
+   * _verticalStretch is the value to scale animation sprites in the Y direction
+   */
+  this._verticalStretch = 1;
+
+  /*
    * _internalWidth and _internalHeight are used for all p5.play
    * calculations, but width and height can be extended. For example,
    * you may want users to always get and set a scaled width:
@@ -1493,10 +1507,20 @@ function Sprite(pInst, _x, _y, _w, _h) {
     enumerable: true,
     configurable: true,
     get: function() {
-      return this._internalWidth;
+      if (this._internalWidth === undefined) {
+        return 100;
+      } else if (this.animation) {
+        return this._internalWidth * this._horizontalStretch;
+      } else {
+        return this._internalWidth;
+      }
     },
     set: function(value) {
-      this._internalWidth = value;
+      if (this.animation) {
+        this._horizontalStretch = value / this._internalWidth;
+      } else {
+        this._internalWidth = value;
+      }
     }
   });
 
@@ -1518,10 +1542,20 @@ function Sprite(pInst, _x, _y, _w, _h) {
     enumerable: true,
     configurable: true,
     get: function() {
-      return this._internalHeight;
+      if (this._internalHeight === undefined) {
+        return 100;
+      } else if (this.animation) {
+        return this._internalHeight * this._verticalStretch;
+      } else {
+        return this._internalHeight;
+      }
     },
     set: function(value) {
-      this._internalHeight = value;
+      if (this.animation) {
+        this._verticalStretch = value / this._internalHeight;
+      } else {
+        this._internalHeight = value;
+      }
     }
   });
 
@@ -1553,6 +1587,26 @@ function Sprite(pInst, _x, _y, _w, _h) {
   this.originalHeight = this._internalHeight;
 
   /**
+   * Gets the scaled width of the sprite.
+   *
+   * @method getScaledWidth
+   * @return {Number} Scaled width
+   */
+  this.getScaledWidth = function() {
+    return this.width * this.scale;
+  };
+
+  /**
+   * Gets the scaled height of the sprite.
+   *
+   * @method getScaledHeight
+   * @return {Number} Scaled height
+   */
+  this.getScaledHeight = function() {
+    return this.height * this.scale;
+  };
+
+  /**
   * True if the sprite has been removed.
   *
   * @property removed
@@ -1582,13 +1636,13 @@ function Sprite(pInst, _x, _y, _w, _h) {
   this.debug = false;
 
   /**
-  * If no image or animations are set this is color of the
+  * If no image or animations are set this is the color of the
   * placeholder rectangle
   *
   * @property shapeColor
   * @type {color}
   */
-  this.shapeColor = color(random(255), random(255), random(255));
+  this.shapeColor = color(127, 127, 127);
 
   /**
   * Groups the sprite belongs to, including allSprites
@@ -1623,6 +1677,120 @@ function Sprite(pInst, _x, _y, _w, _h) {
    * velocity.
    */
   this._sweptCollider = undefined;
+
+  /**
+  * Sprite x position (alias to position.x).
+  *
+  * @property x
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'x', {
+    enumerable: true,
+    get: function() {
+      return this.position.x;
+    },
+    set: function(value) {
+      this.position.x = value;
+    }
+  });
+
+  /**
+  * Sprite y position (alias to position.y).
+  *
+  * @property y
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'y', {
+    enumerable: true,
+    get: function() {
+      return this.position.y;
+    },
+    set: function(value) {
+      this.position.y = value;
+    }
+  });
+
+  /**
+  * Sprite x velocity (alias to velocity.x).
+  *
+  * @property velocityX
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'velocityX', {
+    enumerable: true,
+    get: function() {
+      return this.velocity.x;
+    },
+    set: function(value) {
+      this.velocity.x = value;
+    }
+  });
+
+  /**
+  * Sprite y velocity (alias to velocity.y).
+  *
+  * @property y
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'velocityY', {
+    enumerable: true,
+    get: function() {
+      return this.velocity.y;
+    },
+    set: function(value) {
+      this.velocity.y = value;
+    }
+  });
+
+  /**
+  * Sprite lifetime (alias to life).
+  *
+  * @property lifetime
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'lifetime', {
+    enumerable: true,
+    get: function() {
+      return this.life;
+    },
+    set: function(value) {
+      this.life = value;
+    }
+  });
+
+  /**
+  * Sprite bounciness (alias to restitution).
+  *
+  * @property bounciness
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'bounciness', {
+    enumerable: true,
+    get: function() {
+      return this.restitution;
+    },
+    set: function(value) {
+      this.restitution = value;
+    }
+  });
+
+  /**
+  * Sprite animation frame delay (alias to animation.frameDelay).
+  *
+  * @property frameDelay
+  * @type {Number}
+  */
+  Object.defineProperty(this, 'frameDelay', {
+    enumerable: true,
+    get: function() {
+      return this.animation && this.animation.frameDelay;
+    },
+    set: function(value) {
+      if (this.animation) {
+        this.animation.frameDelay = value;
+      }
+    }
+  });
 
   /**
    * If the sprite is moving, use the swept collider. Otherwise use the actual
@@ -2816,7 +2984,7 @@ function Camera(pInst, x, y, zoom) {
   * @property x
   * @type {Number}
   */
- Object.defineProperty(this, 'x', {
+  Object.defineProperty(this, 'x', {
     enumerable: true,
     get: function() {
       return this.position.x;


### PR DESCRIPTION
Building upon https://github.com/code-dot-org/p5.play/pull/31 and https://github.com/code-dot-org/p5.play/pull/32, here is part 3:

`Sprite` class changes (all changes except `setAnimation()` and the change to `_syncAnimationChanges()`):
* add _horizontalStretch, _verticalStretch props
* modify width, height props
* add getScaledWidth(), getScaledHeight()
* default shapeColor is gray
* add alias props: x, y, velocityX, velocityY, lifetime, bounciness, frameDelay
* add destroy(), setSpeedAndDirection() aliases
* add setFrame(), nextFrame(), previousFrame(), pause(), play(), frameDidChange() animation wrappers
* add pointTo() method
* add isTouching() alias to overlap()
* add bounceOff() method
* modify 'collide' behavior to behave like 'bounce' where target is immovable with a restitution coefficient of zero