### PR TITLE
Code.org p5.play extensions part 4

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2739,6 +2739,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
    *
    * @method isTouching
    * @param {Object} target Sprite or group to check against the current one
+   * @return {Boolean} True if touching
    */
   this.isTouching = this.overlap;
 
@@ -3566,11 +3567,22 @@ function Group() {
   */
   array.overlap = _groupCollide.bind(array, 'overlap');
 
+  /**
+   * Alias for <a href='#method-overlap'>overlap()</a>
+   *
+   * Returns whether or not this group will bounce or collide with another sprite
+   * or group. Modifies the each sprite's touching property object.
+   *
+   * @method isTouching
+   * @param {Object} target Group or Sprite to check against the current one
+   * @return {Boolean} True if touching
+   */
+  array.isTouching = array.overlap;
 
   /**
   * Checks if the the group is overlapping another group or sprite.
-  * If the overlap is positive the sprites in the group will be displaced
-  * by the colliding one to the closest non-overlapping positions.
+  * If the overlap is positive the sprites will bounce with the target(s)
+  * treated as immovable with a restitution coefficient of zero.
   *
   * The check is performed using the colliders. If colliders are not set
   * they will be created automatically from the image/animation bounding box.
@@ -3653,6 +3665,74 @@ function Group() {
   * @return {Boolean} True if overlapping
   */
   array.bounce = _groupCollide.bind(array, 'bounce');
+
+  /**
+  * Checks if the the group is overlapping another group or sprite.
+  * If the overlap is positive the sprites will bounce with the target(s)
+  * treated as immovable.
+  *
+  * The check is performed using the colliders. If colliders are not set
+  * they will be created automatically from the image/animation bounding box.
+  *
+  * A callback function can be specified to perform additional operations
+  * when the overlap occours.
+  * The function will be called for each single sprite overlapping.
+  * The parameter of the function are respectively the
+  * member of the current group and the other sprite passed as parameter.
+  *
+  * @example
+  *     group.bounceOff(otherSprite, explosion);
+  *
+  *     function explosion(spriteA, spriteB) {
+  *       spriteA.remove();
+  *       spriteB.score++;
+  *     }
+  *
+  * @method bounceOff
+  * @param {Object} target Group or Sprite to check against the current one
+  * @param {Function} [callback] The function to be called if overlap is positive
+  * @return {Boolean} True if overlapping
+  */
+  array.bounceOff = _groupCollide.bind(array, 'bounceOff');
+
+  array.setPropertyEach = function(propName, value) {
+    for (var i = 0; i < this.length; i++) {
+      this[i][propName] = value;
+    }
+  };
+
+  array.callMethodEach = function(methodName) {
+    // Copy all arguments after the first parameter into methodArgs:
+    var methodArgs = Array.prototype.slice.call(arguments, 1);
+    // Use a copy of the array in case the method modifies the group
+    var elements = [].concat(this);
+    for (var i = 0; i < elements.length; i++) {
+      elements[i][methodName].apply(elements[i], methodArgs);
+    }
+  };
+
+  array.setDepthEach = array.setPropertyEach.bind(array, 'depth');
+  array.setLifetimeEach = array.setPropertyEach.bind(array, 'lifetime');
+  array.setRotateToDirectionEach = array.setPropertyEach.bind(array, 'rotateToDirection');
+  array.setRotationEach = array.setPropertyEach.bind(array, 'rotation');
+  array.setRotationSpeedEach = array.setPropertyEach.bind(array, 'rotationSpeed');
+  array.setScaleEach = array.setPropertyEach.bind(array, 'scale');
+  array.setColorEach = array.setPropertyEach.bind(array, 'shapeColor');
+  array.setTintEach = array.setPropertyEach.bind(array, 'tint');
+  array.setVisibleEach = array.setPropertyEach.bind(array, 'visible');
+  array.setVelocityXEach = array.setPropertyEach.bind(array, 'velocityX');
+  array.setVelocityYEach = array.setPropertyEach.bind(array, 'velocityY');
+  array.setHeightEach = array.setPropertyEach.bind(array, 'height');
+  array.setWidthEach = array.setPropertyEach.bind(array, 'width');
+
+  array.destroyEach = array.callMethodEach.bind(array, 'destroy');
+  array.pointToEach = array.callMethodEach.bind(array, 'pointTo');
+  array.setAnimationEach = array.callMethodEach.bind(array, 'setAnimation');
+  array.setColliderEach = array.callMethodEach.bind(array, 'setCollider');
+  array.setSpeedAndDirectionEach = array.callMethodEach.bind(array, 'setSpeedAndDirection');
+  array.setVelocityEach = array.callMethodEach.bind(array, 'setVelocity');
+  array.setMirrorXEach = array.callMethodEach.bind(array, 'mirrorX');
+  array.setMirrorYEach = array.callMethodEach.bind(array, 'mirrorY');
 
   return array;
 }

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -278,4 +278,197 @@ describe('Group', function() {
       expect(group.minDepth()).to.equal(bottomSprite.depth);
     });
   });
+
+  describe('methods applying to each sprite', function() {
+    it('setSpeedAndDirectionEach calls setSpeedAndDirection for each member', function() {
+      var sprite1 = pInst.createSprite(0, 0);
+      var sprite2 = pInst.createSprite(0, 0);
+      var group = pInst.createGroup();
+      group.add(sprite1);
+      group.add(sprite2);
+      sinon.spy(sprite1, 'setSpeedAndDirection');
+      sinon.spy(sprite2, 'setSpeedAndDirection');
+      expect(sprite1.setSpeedAndDirection.calledOnce).to.be.false;
+      expect(sprite2.setSpeedAndDirection.calledOnce).to.be.false;
+
+      var speed = 5;
+      var direction = 180;
+      group.setSpeedAndDirectionEach(speed, direction);
+      expect(sprite1.setSpeedAndDirection.calledOnce).to.be.true;
+      expect(sprite2.setSpeedAndDirection.calledOnce).to.be.true;
+      expect(sprite1.setSpeedAndDirection.calledWith(speed, direction)).to.be.true;
+      expect(sprite2.setSpeedAndDirection.calledWith(speed, direction)).to.be.true;
+    });
+
+    it('removes every element', function() {
+      var group = pInst.createGroup();
+      for (var i = 0; i < 2; i++) {
+        group.add(pInst.createSprite(0, 0));
+      }
+      group.destroyEach();
+
+      expect(group).to.be.empty;
+    });
+  });
+
+  describe('collision methods', function() {
+    var sprite1, sprite2, targetSprite, group;
+
+    beforeEach(function() {
+      sprite1 = pInst.createSprite(0, 0, 100, 100);
+      sprite2 = pInst.createSprite(400, 400, 100, 100);
+      targetSprite = pInst.createSprite(200, 200, 100, 100);
+      group = pInst.createGroup();
+      group.add(sprite1);
+      group.add(sprite2);
+    });
+
+    describe('no sprite in group overlaps target sprite', function() {
+      it('returns false for isTouching', function() {
+        var result = group.isTouching(targetSprite);
+        expect(result).to.equal(false);
+      });
+
+      it('returns false for collide', function() {
+        var result = group.collide(targetSprite);
+        expect(result).to.equal(false);
+      });
+
+      it('returns false for bounce', function() {
+        var result = group.bounce(targetSprite);
+        expect(result).to.equal(false);
+      });
+
+      it('returns false for bounceOff', function() {
+        var result = group.bounceOff(targetSprite);
+        expect(result).to.equal(false);
+      });
+
+      it('returns false for overlap', function() {
+        var result = group.overlap(targetSprite);
+        expect(result).to.equal(false);
+      });
+
+      it('returns false for displace', function() {
+        var result = group.displace(targetSprite);
+        expect(result).to.equal(false);
+      });
+    });
+
+    describe('first sprite in group overlaps target sprite', function() {
+      beforeEach(function() {
+        // Make sprite1 overlap with target sprite
+        sprite1.x = targetSprite.x;
+        sprite1.y = targetSprite.y;
+      });
+
+      it('returns true for isTouching', function() {
+        var result = group.isTouching(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for collide', function() {
+        var result = group.collide(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for bounce', function() {
+        var result = group.bounce(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for bounceOff', function() {
+        var result = group.bounceOff(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for overlap', function() {
+        var result = group.overlap(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for displace', function() {
+        var result = group.displace(targetSprite);
+        expect(result).to.equal(true);
+      });
+    });
+
+    describe('last sprite in group overlaps target sprite', function() {
+      beforeEach(function() {
+        // Make sprite1 overlap with target sprite
+        sprite2.x = targetSprite.x;
+        sprite2.y = targetSprite.y;
+      });
+
+      it('returns true for isTouching', function() {
+        var result = group.isTouching(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for collide', function() {
+        var result = group.collide(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for bounce', function() {
+        var result = group.bounce(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for bounceOff', function() {
+        var result = group.bounceOff(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for overlap', function() {
+        var result = group.overlap(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for displace', function() {
+        var result = group.displace(targetSprite);
+        expect(result).to.equal(true);
+      });
+    });
+
+    describe('every sprite in group overlaps target sprite', function() {
+      beforeEach(function() {
+        // Make sprite1 overlap with target sprite
+        sprite1.x = targetSprite.x;
+        sprite1.y = targetSprite.y;
+        sprite2.x = targetSprite.x;
+        sprite2.y = targetSprite.y;
+      });
+
+      it('returns true for isTouching', function() {
+        var result = group.isTouching(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for collide', function() {
+        var result = group.collide(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for bounce', function() {
+        var result = group.bounce(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for bounceOff', function() {
+        var result = group.bounceOff(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for overlap', function() {
+        var result = group.overlap(targetSprite);
+        expect(result).to.equal(true);
+      });
+
+      it('returns true for displace', function() {
+        var result = group.displace(targetSprite);
+        expect(result).to.equal(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Building upon https://github.com/code-dot-org/p5.play/pull/31, https://github.com/code-dot-org/p5.play/pull/32, and https://github.com/code-dot-org/p5.play/pull/33 here is part 4:

`Group` class changes:
* add bounceOff()
* modify docs for collide()
* add isTouching()
* add set__Each() methods for setting properties on all elements in group
* add set__Each() methods for calling methods on all elements in group
* add cdo Group test cases