### PR TITLE
Code.org p5.play extensions part 5

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -148,6 +148,17 @@ var degrees = p5.prototype.degrees;
 //                         p5 overrides
 // =============================================================================
 
+// Make the fill color default to gray (127, 127, 127) each time a new canvas is
+// created.
+if (!p5.prototype.originalCreateCanvas_) {
+  p5.prototype.originalCreateCanvas_ = p5.prototype.createCanvas;
+  p5.prototype.createCanvas = function() {
+    var result = this.originalCreateCanvas_.apply(this, arguments);
+    this.fill(this.color(127, 127, 127));
+    return result;
+  };
+}
+
 // Make width and height optional for ellipse() - default to 50
 // Save the original implementation to allow for optional parameters.
 if (!p5.prototype.originalEllipse_) {
@@ -859,18 +870,45 @@ p5.prototype.mouseWentDown = function(buttonCode) {
 };
 
 /**
+ * Returns a constant for a mouse state given a string or a mouse button constant.
+ *
+ * @private
+ * @method _clickKeyFromString
+ * @param {Number|String} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+ *   or string 'leftButton', 'rightButton', or 'centerButton'
+ * @return {Number} Mouse button constant LEFT, RIGHT or CENTER or value of buttonCode
+ */
+p5.prototype._clickKeyFromString = function(buttonCode) {
+  if (this.CLICK_KEY[buttonCode]) {
+    return this.CLICK_KEY[buttonCode];
+  } else {
+    return buttonCode;
+  }
+};
+
+// Map of strings to constants for mouse states.
+p5.prototype.CLICK_KEY = {
+  'leftButton': p5.prototype.LEFT,
+  'rightButton': p5.prototype.RIGHT,
+  'centerButton': p5.prototype.CENTER
+};
+
+/**
  * Detects if a mouse button is in the given state during the last cycle.
  * Helper method encapsulating common mouse button state logic; it may be
  * preferable to call mouseWentUp, etc, directly.
  *
  * @private
  * @method _isMouseButtonInState
- * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+ * @param {Number|String} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+ *   or string 'leftButton', 'rightButton', or 'centerButton'
  * @param {Number} state
  * @return {boolean} True if the button was in the given state
  */
 p5.prototype._isMouseButtonInState = function(buttonCode, state) {
   var mouseStates = this._p5play.mouseStates;
+
+  buttonCode = this._clickKeyFromString(buttonCode);
 
   if(buttonCode === undefined)
     buttonCode = this.LEFT;
@@ -3738,6 +3776,44 @@ function Group() {
 }
 
 p5.prototype.Group = Group;
+
+/**
+ * Creates four edge sprites and adds them to a group. Each edge is just outside
+ * of the canvas and has a thickness of 100. After calling this function,
+ * the following properties are exposed and populated with sprites:
+ * leftEdge, rightEdge, topEdge, bottomEdge
+ *
+ * The 'edges' property is populated with a group containing those four sprites.
+ *
+ * If this edge sprites have already been created, the function returns the
+ * existing edges group immediately.
+ *
+ * @method createEdgeSprites
+ * @return {Group} The edges group
+ */
+p5.prototype.createEdgeSprites = function() {
+  if (this.edges) {
+    return this.edges;
+  }
+
+  var edgeThickness = 100;
+
+  var width = this._curElement.elt.offsetWidth;
+  var height = this._curElement.elt.offsetHeight;
+
+  this.leftEdge = this.createSprite(-edgeThickness / 2, height / 2, edgeThickness, height);
+  this.rightEdge = this.createSprite(width + (edgeThickness / 2), height / 2, edgeThickness, height);
+  this.topEdge = this.createSprite(width / 2, -edgeThickness / 2, width, edgeThickness);
+  this.bottomEdge = this.createSprite(width / 2, height + (edgeThickness / 2), width, edgeThickness);
+
+  this.edges = this.createGroup();
+  this.edges.add(this.leftEdge);
+  this.edges.add(this.rightEdge);
+  this.edges.add(this.topEdge);
+  this.edges.add(this.bottomEdge);
+
+  return this.edges;
+};
 
 /**
  * An Animation object contains a series of images (p5.Image) that

--- a/test/index.html
+++ b/test/index.html
@@ -29,6 +29,7 @@
     <script src="unit/collisions/sprite-collide.js"></script>
     <script src="unit/collisions/sprite-displace.js"></script>
     <script src="unit/collisions/sprite-overlap.js"></script>
+    <script src="unit/general.js"></script>
     <script src="unit/group.js"></script>
     <script src="unit/input.js"></script>
     <script src="unit/keycodes.js"></script>

--- a/test/unit/general.js
+++ b/test/unit/general.js
@@ -1,0 +1,50 @@
+describe('General', function() {
+  var pInst;
+
+  beforeEach(function() {
+    pInst = new p5(function() {});
+  });
+
+  afterEach(function() {
+    pInst.remove();
+  });
+
+  describe('createEdgeSprites method', function() {
+    var edgeGroup;
+
+    beforeEach(function() {
+      edgeGroup = pInst.createEdgeSprites();
+    });
+
+    it('returns a group of sprites', function() {
+      expect(edgeGroup).to.equal(pInst.edges);
+      expect(edgeGroup.contains(pInst.rightEdge)).to.equal(true);
+      expect(edgeGroup.contains(pInst.leftEdge)).to.equal(true);
+      expect(edgeGroup.contains(pInst.bottomEdge)).to.equal(true);
+      expect(edgeGroup.contains(pInst.topEdge)).to.equal(true);
+      expect(edgeGroup.maxDepth()).to.equal(4);
+    });
+
+    it('creates edge sprites off screen', function() {
+      expect(pInst.leftEdge.position.x).to.equal(-50);
+      expect(pInst.leftEdge.position.y).to.equal(200);
+      expect(pInst.leftEdge.width).to.equal(100);
+      expect(pInst.leftEdge.height).to.equal(400);
+
+      expect(pInst.rightEdge.position.x).to.equal(450);
+      expect(pInst.rightEdge.position.y).to.equal(200);
+      expect(pInst.rightEdge.width).to.equal(100);
+      expect(pInst.rightEdge.height).to.equal(400);
+
+      expect(pInst.bottomEdge.position.x).to.equal(200);
+      expect(pInst.bottomEdge.position.y).to.equal(450);
+      expect(pInst.bottomEdge.width).to.equal(400);
+      expect(pInst.bottomEdge.height).to.equal(100);
+
+      expect(pInst.topEdge.position.x).to.equal(200);
+      expect(pInst.topEdge.position.y).to.equal(-50);
+      expect(pInst.topEdge.width).to.equal(400);
+      expect(pInst.topEdge.height).to.equal(100);
+    });
+  });
+});

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -1,4 +1,5 @@
 describe('Sprite', function() {
+  var expectVectorsAreClose = p5PlayAssertions.expectVectorsAreClose;
   var MARGIN_OF_ERROR = 0.0000001;
   var pInst;
 
@@ -1716,12 +1717,5 @@ describe('Sprite', function() {
     animation.looping = looping;
     animation.frameDelay = 1;
     return animation;
-  }
-
-  function expectVectorsAreClose(vA, vB) {
-    var failMsg = 'Expected <' + vA.x + ', ' + vA.y + '> to equal <' +
-    vB.x + ', ' + vB.y + '>';
-    expect(vA.x).to.be.closeTo(vB.x, 0.00001, failMsg);
-    expect(vA.y).to.be.closeTo(vB.y, 0.00001, failMsg);
   }
 });


### PR DESCRIPTION
Now circling back to a few general changes we made to `p5.play`:

* default fill color to gray (127, 127, 127)
* allow mouse methods to accept strings ('leftButton', 'rightButton', 'centerButton') in addition to button codes
* add createEdgeSprites() and test cases