### PR TITLE
Swap order of applying mirror and rotation

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2182,12 +2182,12 @@ function Sprite(pInst, _x, _y, _w, _h) {
       imageMode(CENTER);
 
       translate(this.position.x, this.position.y);
-      scale(this._getScaleX()*dirX, this._getScaleY()*dirY);
       if (pInst._angleMode === pInst.RADIANS) {
         rotate(radians(this.rotation));
       } else {
         rotate(this.rotation);
       }
+      scale(this._getScaleX()*dirX, this._getScaleY()*dirY);
       this.draw();
       //draw debug info
       pop();


### PR DESCRIPTION
We discovered in some classroom testing that rotation and mirroring interact in unexpected ways for students. The current behavior mirrors a sprite across the canvas x/y, regardless of rotation. This makes it difficult to turn a sprite back/forth if it's been rotated, but also causes continual rotation to switch direction when mirrored. Eg:

![rotation_mirror](https://user-images.githubusercontent.com/2744615/44319379-577ba680-a3f0-11e8-829a-5b52dc83b635.gif)

If we switch the order in which mirroring and rotation are applied in `sprite.display`, then we can ensure that `sprite.mirrorX` and `sprite.mirrorY` are applied relative to sprite rotation instead of based on the canvas x/y. This would be a breaking change for any projects currently relying on mirroring to ignore sprite rotation, though I'm not sure if it's a big enough break that we should look through existing projects to see what the scale of impact would be if we chose to make this change.