### PR TITLE
Code.org p5.play extensions part 6

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1546,14 +1546,14 @@ function Sprite(pInst, _x, _y, _w, _h) {
     get: function() {
       if (this._internalWidth === undefined) {
         return 100;
-      } else if (this.animation) {
+      } else if (this.animation && pInst._fixedSpriteAnimationFrameSizes) {
         return this._internalWidth * this._horizontalStretch;
       } else {
         return this._internalWidth;
       }
     },
     set: function(value) {
-      if (this.animation) {
+      if (this.animation && pInst._fixedSpriteAnimationFrameSizes) {
         this._horizontalStretch = value / this._internalWidth;
       } else {
         this._internalWidth = value;
@@ -1581,14 +1581,14 @@ function Sprite(pInst, _x, _y, _w, _h) {
     get: function() {
       if (this._internalHeight === undefined) {
         return 100;
-      } else if (this.animation) {
+      } else if (this.animation && pInst._fixedSpriteAnimationFrameSizes) {
         return this._internalHeight * this._verticalStretch;
       } else {
         return this._internalHeight;
       }
     },
     set: function(value) {
-      if (this.animation) {
+      if (this.animation && pInst._fixedSpriteAnimationFrameSizes) {
         this._verticalStretch = value / this._internalHeight;
       } else {
         this._internalHeight = value;
@@ -1851,6 +1851,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
    * Keep animation properties in sync with how the animation changes.
    */
   this._syncAnimationSizes = function(animations, currentAnimation) {
+    if (pInst._fixedSpriteAnimationFrameSizes) {
+      return;
+    }
     if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
     {
       this._internalWidth = animations[currentAnimation].getWidth()*abs(this._getScaleX());
@@ -2145,20 +2148,30 @@ function Sprite(pInst, _x, _y, _w, _h) {
   /*
    * Returns the value the sprite should be scaled in the X direction.
    * Used to calculate rendering and collisions.
+   * When _fixedSpriteAnimationFrameSizes is set, the scale value should
+   * include the horizontal stretch for animations.
    * @private
    */
   this._getScaleX = function()
   {
+    if (pInst._fixedSpriteAnimationFrameSizes) {
+      return this.scale * this._horizontalStretch;
+    }
     return this.scale;
   };
 
   /*
    * Returns the value the sprite should be scaled in the Y direction.
    * Used to calculate rendering and collisions.
+   * When _fixedSpriteAnimationFrameSizes is set, the scale value should
+   * include the vertical stretch for animations.
    * @private
    */
   this._getScaleY = function()
   {
+    if (pInst._fixedSpriteAnimationFrameSizes) {
+      return this.scale * this._verticalStretch;
+    }
     return this.scale;
   };
 
@@ -2682,6 +2695,31 @@ function Sprite(pInst, _x, _y, _w, _h) {
     {
       currentAnimation = label;
       this.animation = animations[label];
+    }
+  };
+
+  /**
+  * Sets the animation from a list in _predefinedSpriteAnimations.
+  *
+  * @method setAnimation
+  * @private
+  * @param {String} label Animation identifier
+  */
+  this.setAnimation = function(animationName) {
+    if (animationName === this.getAnimationLabel()) {
+      return;
+    }
+
+    var animation = pInst._predefinedSpriteAnimations &&
+        pInst._predefinedSpriteAnimations[animationName];
+    if (typeof animation === 'undefined') {
+      throw new Error('Unable to find an animation named "' + animationName +
+          '".  Please make sure the animation exists.');
+    }
+    this.addAnimation(animationName, animation);
+    this.changeAnimation(animationName);
+    if (pInst._pauseSpriteAnimationsByDefault) {
+      this.pause();
     }
   };
 

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -1700,6 +1700,79 @@ describe('Sprite', function() {
     });
   });
 
+  describe('_fixedSpriteAnimationFrameSizes property', function() {
+    var pInst, testAnimation;
+
+    beforeEach(function() {
+      pInst = new p5(function() {});
+      // Create a test animation where the initial frame size is 50x50,
+      // the next frame is 50x60, and the 3rd is 50x70:
+      testAnimation = createTestAnimation(3, false, 10);
+    });
+
+    afterEach(function() {
+      pInst.remove();
+    });
+
+    describe('_fixedSpriteAnimationFrameSizes is true', function() {
+      var sprite;
+
+      beforeEach(function() {
+        pInst._fixedSpriteAnimationFrameSizes = true;
+        sprite = pInst.createSprite(0, 0);
+        sprite.addAnimation('testAnim', testAnimation);
+      });
+
+      it('initial sprite dimensions come from animation first frame size', function() {
+        expect(sprite.width).to.equal(50);
+        expect(sprite.height).to.equal(50);
+      });
+
+      it('sprite dimensions stay fixed when advancing to different animation frame sizes', function() {
+        sprite.update();
+        expect(sprite.width).to.equal(50);
+        expect(sprite.height).to.equal(50);
+      });
+
+      it('allows sprite dimensions to be changed when animation is set with different frame size', function() {
+        sprite.width = 190;
+        sprite.height = 80;
+        sprite.update();
+        expect(sprite.width).to.equal(190);
+        expect(sprite.height).to.equal(80);
+      });
+    });
+
+    describe('_fixedSpriteAnimationFrameSizes is false', function() {
+      var sprite;
+
+      beforeEach(function() {
+        pInst._fixedSpriteAnimationFrameSizes = false;
+        sprite = pInst.createSprite(0, 0);
+        sprite.addAnimation('testAnim', testAnimation);
+      });
+
+      it('initial sprite dimensions come from animation first frame size', function() {
+        expect(sprite.width).to.equal(50);
+        expect(sprite.height).to.equal(50);
+      });
+
+      it('sprite dimensions change when advancing to different animation frame sizes', function() {
+        sprite.update();
+        expect(sprite.width).to.equal(50);
+        expect(sprite.height).to.equal(60);
+      });
+
+      it('does not allow sprite dimensions to be changed when animation is set with different frame size', function() {
+        sprite.width = 190;
+        sprite.height = 80;
+        sprite.update();
+        expect(sprite.width).to.equal(50);
+        expect(sprite.height).to.equal(60);
+      });
+    });
+  });
+
   describe('setAnimation(label)', function() {
     var ANIMATION_LABEL = 'animation1', SECOND_ANIMATION_LABEL = 'animation2';
     var sprite, predefinedSpriteAnimations;
@@ -1877,17 +1950,22 @@ describe('Sprite', function() {
     expect(anim1.looping).to.equal(anim2.looping);
   }
 
-  function createTestAnimation(frameCount, looping) {
+  function createTestAnimation(frameCount, looping, heightIncreasePerFrame) {
     if (frameCount === undefined) {
       frameCount = 1;
     }
     if (looping === undefined) {
       looping = true;
     }
+    if (heightIncreasePerFrame === undefined) {
+      heightIncreasePerFrame = 0;
+    }
     var image = new p5.Image(100, 100, pInst);
     var frames = [];
+    var nextHeight = 50;
     for (var i = 0; i < frameCount; i++) {
-      frames.push({name: i, frame: {x: 0, y: 0, width: 50, height: 50}});
+      frames.push({name: i, frame: {x: 0, y: 0, width: 50, height: nextHeight}});
+      nextHeight += heightIncreasePerFrame;
     }
     var sheet = new pInst.SpriteSheet(image, frames);
     var animation = new pInst.Animation(sheet);


### PR DESCRIPTION
Wrapping up our p5.play extensions. These changes are a little trickier for two reasons:
(1) `setAnimation()` relied on "project" or "level" state
(2) We had created new behavior around `syncAnimationSizes()` which had corresponding behavioral changes when setting the width or height of a `Sprite`.

The project state needed for `setAnimation()` can now be set on the instance by populating the private `_predefinedSpriteAnimations` property.

A private property to enable the new fixed sprite/animation size behavior (`_fixedSpriteAnimationFrameSizes`) can now be set on the instance and p5.play supports either behavior based on the property value.

* Add `_fixedSpriteAnimationFrameSizes` property on `pInst`, changes `Sprite` to utilize `_horizontalStretch` and `_verticalStretch`
* Add `setAnimation()` to `Sprite`, requiring `_predefinedSpriteAnimations` to be set on `pInst` (`_pauseSpriteAnimationsByDefault` optional)
* Add test cases for `setAnimation()`