### PR TITLE
cdo p5.play extensions - cleanup isTouching, version 1.3.0

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2808,9 +2808,12 @@ function Sprite(pInst, _x, _y, _w, _h) {
   };
 
   /**
-   * Alias for <a href='#method-overlap'>overlap()</a>
+   * Alias for <a href='#method-overlap'>overlap()</a>, except without a
+   * callback parameter.
+   * The check is performed using the colliders. If colliders are not set
+   * they will be created automatically from the image/animation bounding box.
    *
-   * Returns whether or not this sprite will bounce or collide with another sprite
+   * Returns whether or not this sprite is overlapping another sprite
    * or group. Modifies the sprite's touching property object.
    *
    * @method isTouching
@@ -2951,9 +2954,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
    *
    * @method _collideWith
    * @private
-   * @param {string} type - 'overlap', 'displace', 'collide', 'bounce' or 'bounceOff'
+   * @param {string} type - 'overlap', 'isTouching', 'displace', 'collide',
+   *   'bounce' or 'bounceOff'
    * @param {Sprite|Group} target
-   * @param {function} callback - if collision occurred
+   * @param {function} callback - if collision occurred (ignored for 'isTouching')
    * @return {boolean} true if a collision occurred
    */
   this._collideWith = function(type, target, callback) {
@@ -3000,9 +3004,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
    *
    * @method _collideWithOne
    * @private
-   * @param {string} type - 'overlap', 'displace', 'collide', 'bounce' or 'bounceOff'
+   * @param {string} type - 'overlap', 'isTouching', 'displace', 'collide',
+   *   'bounce' or 'bounceOff'
    * @param {Sprite} other
-   * @param {function} callback - if collision occurred
+   * @param {function} callback - if collision occurred (ignored for 'isTouching')
    * @return {boolean} true if a collision occurred
    */
   this._collideWithOne = function(type, other, callback) {
@@ -3115,9 +3120,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
     other.immovable = originalOtherImmovable;
     other.restitution = originalOtherRestitution;
 
-    // Finally, for all collision types call the callback and record
-    // that collision occurred.
-    if (typeof callback === 'function') {
+    // Finally, for all collision types except 'isTouching', call the callback
+    // and record that collision occurred.
+    if (typeof callback === 'function' && type !== 'isTouching') {
       callback.call(this, this, other);
     }
     return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.2.2-cdo",
+  "version": "1.3.0-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
* `Sprite.isTouching()` and `Group.isTouching()` are the same as `Sprite.overlap()` and `Group.overlap()`, but are supposed to ignore the `callback` parameter. Modified the code to ensure that they won't call the `callback` parameter, even if it is supplied to be consistent with our monkey-patched version of `isTouching()`. Updated the autodocs to make this clear.
* In preparation for publishing to npm, updated the version to `1.3.0-cdo`