### PR TITLE
Code.org p5.play extensions - add World object, set version to 1.3.1-cdo

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -64,6 +64,9 @@ p5.prototype.registerMethod('init', function p5PlayInit() {
     width: 400,
     height: 400
   };
+
+  var startDate = new Date();
+  this._startTime = startDate.getTime();
 });
 
 // This provides a way for us to lazily define properties that
@@ -567,6 +570,49 @@ p5.prototype.rgb = function(r, g, b, a) {
 p5.prototype.createGroup = function() {
   return new this.Group();
 };
+
+defineLazyP5Property('World', function() {
+  var World = {
+    pInst: this
+  };
+
+  function createReadOnlyP5PropertyAlias(name) {
+    Object.defineProperty(World, name, {
+      enumerable: true,
+      get: function() {
+        return this.pInst[name];
+      }
+    });
+  }
+
+  createReadOnlyP5PropertyAlias('width');
+  createReadOnlyP5PropertyAlias('height');
+  createReadOnlyP5PropertyAlias('mouseX');
+  createReadOnlyP5PropertyAlias('mouseY');
+  createReadOnlyP5PropertyAlias('allSprites');
+  createReadOnlyP5PropertyAlias('frameCount');
+
+  Object.defineProperty(World, 'frameRate', {
+    enumerable: true,
+    get: function() {
+      return this.pInst.frameRate();
+    },
+    set: function(value) {
+      this.pInst.frameRate(value);
+    }
+  });
+
+  Object.defineProperty(World, 'seconds', {
+    enumerable: true,
+    get: function() {
+      var currentDate = new Date();
+      var currentTime = currentDate.getTime();
+      return Math.round((currentTime - this.pInst._startTime) / 1000);
+    }
+  });
+
+  return World;
+});
 
 p5.prototype.spriteUpdate = true;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.3.0-cdo",
+  "version": "1.3.1-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {

--- a/test/unit/general.js
+++ b/test/unit/general.js
@@ -47,4 +47,21 @@ describe('General', function() {
       expect(pInst.topEdge.height).to.equal(100);
     });
   });
+
+  describe('World.seconds', function() {
+    it('returns time passed in seconds', function() {
+      sinon.stub(Date.prototype, 'getTime');
+      // Time at the start of the program.
+      Date.prototype.getTime.onCall(0).returns(5300);
+      // Time when seconds gets called.
+      Date.prototype.getTime.onCall(1).returns(10000);
+
+      // Re-init p5 to capture the _startTime
+      pInst.remove();
+      pInst = new p5(function() {});
+
+      expect(pInst.World.seconds).to.equal(5);
+      Date.prototype.getTime.restore();
+    });
+  });
 });


### PR DESCRIPTION
* Expose `World` object from GameLab directly in `p5.play`, with the following properties:
  * `frameRate`
  * `seconds`
  * `width`
  * `height`
  * `mouseX`
  * `mouseY`
  * `allSprites`
  * `frameCount`
* Migrate `World.seconds` test case from code.org's repo