### PR TITLE
add SpriteSheet support for texture packing

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4209,8 +4209,10 @@ function Animation(pInst) {
       if (frame_info) {
         var missingX = (frame_info.sourceW || frame_info.width) - frame_info.width;
         var missingY = (frame_info.sourceH || frame_info.height) - frame_info.height;
-        xTranslate -= (missingX - (frame_info.sourceX || 0)) / 2;
-        yTranslate -= (missingY - (frame_info.sourceY || 0)) / 2;
+        // If the count of missing (transparent) pixels is not equally balanced on
+        // the left vs. right or top vs. bottom, we adjust the translation:
+        xTranslate += ((frame_info.sourceX || 0) - missingX / 2);
+        yTranslate += ((frame_info.sourceY || 0) - missingY / 2);
       }
 
       pInst.translate(xTranslate, yTranslate);
@@ -4221,9 +4223,10 @@ function Animation(pInst) {
       }
 
       if (frame_info) {
-        pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y,
+        pInst.image(this.spriteSheet.image,
+          frame_info.x, frame_info.y,
           frame_info.width, frame_info.height,
-          this.offX + (frame_info.sourceX || 0) / 2, this.offY + (frame_info.sourceY || 0) / 2,
+          this.offX, this.offY,
           frame_info.width, frame_info.height);
       } else if (image) {
         pInst.image(image, this.offX, this.offY);

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4123,6 +4123,16 @@ function Animation(pInst) {
   {
     this.spriteSheet = frameArguments[0];
     this.images = this.spriteSheet.frames.map( function(f) {
+      if (f.spriteSourceSize && f.sourceSize) {
+        return Object.assign(f.frame, {
+          width: f.frame.w,
+          height: f.frame.h,
+          sourceX: f.spriteSourceSize.x,
+          sourceY: f.spriteSourceSize.y,
+          sourceW: f.sourceSize.w,
+          sourceH: f.sourceSize.h,
+        });
+      }
       return f.frame;
     });
   }
@@ -4189,25 +4199,35 @@ function Animation(pInst) {
       pInst.push();
       pInst.imageMode(CENTER);
 
-      pInst.translate(this.xpos, this.ypos);
+      var xTranslate = this.xpos;
+      var yTranslate = this.ypos;
+      var image = this.images[frame];
+      var frame_info = this.spriteSheet && image;
+
+      // Adjust translation if we're dealing with a texture packed spritesheet
+      // (with sourceW, sourceH, sourceX, sourceY props on our images array)
+      if (frame_info) {
+        var missingX = (frame_info.sourceW || frame_info.width) - frame_info.width;
+        var missingY = (frame_info.sourceH || frame_info.height) - frame_info.height;
+        xTranslate -= (missingX - (frame_info.sourceX || 0)) / 2;
+        yTranslate -= (missingY - (frame_info.sourceY || 0)) / 2;
+      }
+
+      pInst.translate(xTranslate, yTranslate);
       if (pInst._angleMode === pInst.RADIANS) {
         pInst.rotate(radians(this.rotation));
       } else {
         pInst.rotate(this.rotation);
       }
 
-      if(this.images[frame] !== undefined)
-      {
-        if (this.spriteSheet) {
-          var frame_info = this.images[frame];
-          pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y, frame_info.width,
-            frame_info.height, this.offX, this.offY, frame_info.width, frame_info.height);
-        } else {
-          pInst.image(this.images[frame], this.offX, this.offY);
-        }
-      }
-      else
-      {
+      if (frame_info) {
+        pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y,
+          frame_info.width, frame_info.height,
+          this.offX + (frame_info.sourceX || 0) / 2, this.offY + (frame_info.sourceY || 0) / 2,
+          frame_info.width, frame_info.height);
+      } else if (image) {
+        pInst.image(image, this.offX, this.offY);
+      } else {
         pInst.print('Warning undefined frame '+frame);
         //this.isActive = false;
       }
@@ -4414,7 +4434,7 @@ function Animation(pInst) {
   */
   this.getWidth = function() {
     if (this.images[frame]) {
-      return this.images[frame].width;
+      return this.images[frame].sourceW || this.images[frame].width;
     } else {
       return 1;
     }
@@ -4429,7 +4449,7 @@ function Animation(pInst) {
   */
   this.getHeight = function() {
     if (this.images[frame]) {
-      return this.images[frame].height;
+      return this.images[frame].sourceH || this.images[frame].height;
     } else {
       return 1;
     }
@@ -4540,19 +4560,41 @@ function SpriteSheet(pInst) {
   this.drawFrame = function(frame_name, x, y, width, height) {
     var frameToDraw;
     if (typeof frame_name === 'number') {
-      frameToDraw = this.frames[frame_name].frame;
+      frameToDraw = this.frames[frame_name];
     } else {
       for (var i = 0; i < this.frames.length; i++) {
         if (this.frames[i].name === frame_name) {
-          frameToDraw = this.frames[i].frame;
+          frameToDraw = this.frames[i];
           break;
         }
       }
     }
-    var dWidth = width || frameToDraw.width;
-    var dHeight = height || frameToDraw.height;
-    pInst.image(this.image, frameToDraw.x, frameToDraw.y,
-      frameToDraw.width, frameToDraw.height, x, y, dWidth, dHeight);
+    var frameWidth = frameToDraw.frame.width || frameToDraw.frame.w;
+    var frameHeight = frameToDraw.frame.height || frameToDraw.frame.h;
+    var dWidth = width || frameWidth;
+    var dHeight = height || frameHeight;
+
+    // Adjust how we draw if we're dealing with a texture packed spritesheet
+    // (in particular, we treat supplied width and height params as an intention
+    //  to scale versus the sourceSize [before packing])
+    if (frameToDraw.spriteSourceSize && frameToDraw.sourceSize) {
+      var frameSizeScaleX = frameWidth / frameToDraw.sourceSize.w;
+      var frameSizeScaleY = frameHeight / frameToDraw.sourceSize.h;
+      if (width) {
+        x += (frameToDraw.spriteSourceSize.x * dWidth / frameToDraw.sourceSize.w);
+        dWidth = width * frameSizeScaleX;
+      } else {
+        x += frameToDraw.spriteSourceSize.x;
+      }
+      if (height) {
+        y += (frameToDraw.spriteSourceSize.y * dHeight / frameToDraw.sourceSize.h);
+        dHeight = height * frameSizeScaleY;
+      } else {
+        y += frameToDraw.spriteSourceSize.y;
+      }
+    }
+    pInst.image(this.image, frameToDraw.frame.x, frameToDraw.frame.y,
+      frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.3.2-cdo",
+  "version": "1.3.3-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
* Add support to `SpriteSheet` for dealing with texture packed sprite sheets
  * (support was already present for passing an array of objects that define each frame) - this is the beginning of what is needed, but it didn't support the notion of preserving a sprite frame's original size (`sourceSize`) such that you could avoid including transparent pixels in the spritesheet
* With this PR, the texture atlas JSON output from __TexturePacker__ is now supported, which looks like this:
```
[
{
	"filename": "Unicorn_Floss_00.png",
	"frame": {"x":163,"y":804,"w":120,"h":269},
	"rotated": false,
	"trimmed": true,
	"spriteSourceSize": {"x":90,"y":24,"w":120,"h":269},
	"sourceSize": {"w":300,"h":300}
},
{
	"filename": "Unicorn_Floss_01.png",
	"frame": {"x":613,"y":269,"w":120,"h":269},
	"rotated": false,
	"trimmed": true,
	"spriteSourceSize": {"x":92,"y":24,"w":120,"h":269},
	"sourceSize": {"w":300,"h":300}
}
]
```
* `SpriteSheet` did support `frame` - it now allows `w` and `h` in addition to `width` and `height` for compatibility with this form of output
* `SpriteSheet` now supports `spriteSourceSize` (with `x`, `y`, `w`, and `h`) and `sourceSize` (with `w` and `h`)
  * `SpriteSheet.drawFrame()` has been updated to handle this scenario
  * Some of the new properties are now stored in the `Animation` frame info (stored in the `images` array when a `spriteSheet` is present)
  * `Animation.draw()` has been updated to support this type of sprite sheet
* `SpriteSheet` already supports an optional `name` per frame, which is not included in the default JSON from __TexturePacker__
* `SpriteSheet` ignores the `rotated` and `trimmed` properties. It supports `trimmed` sprite sheets, but deduces that from the other properties. It does not support `rotated` frames within a sprite sheet image.