### PR TITLE
Add support for sprite sheet without p5 image

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -434,7 +434,7 @@ p5.prototype.loadImageElement = function(path, successCallback, failureCallback)
     }
   };
   img.onerror = function(e) {
-    p5._friendlyFileLoadError(0,img.src);
+    p5._friendlyFileLoadError(0, img.src);
     // don't get failure callback mixed up with decrementPreload
     if ((typeof failureCallback === 'function') &&
       (failureCallback !== decrementPreload)) {
@@ -535,16 +535,16 @@ p5.prototype.imageElement = function(imgEl, sx, sy, sWidth, sHeight, dx, dy, dWi
 
   function modeAdjust(a, b, c, d, mode) {
     if (mode === p5.prototype.CORNER) {
-      return { x: a, y: b, w: c, h: d };
+      return {x: a, y: b, w: c, h: d};
     } else if (mode === p5.prototype.CORNERS) {
-      return { x: a, y: b, w: c-a, h: d-b };
+      return {x: a, y: b, w: c-a, h: d-b};
     } else if (mode === p5.prototype.RADIUS) {
-      return { x: a-c, y: b-d, w: 2*c, h: 2*d };
+      return {x: a-c, y: b-d, w: 2*c, h: 2*d};
     } else if (mode === p5.prototype.CENTER) {
-      return { x: a-c*0.5, y: b-d*0.5, w: c, h: d };
+      return {x: a-c*0.5, y: b-d*0.5, w: c, h: d};
     }
   }
-  
+
   if (arguments.length <= 5) {
     dx = sx || 0;
     dy = sy || 0;
@@ -571,9 +571,19 @@ p5.prototype.imageElement = function(imgEl, sx, sy, sWidth, sHeight, dx, dy, dWi
   var vals = modeAdjust(dx, dy, dWidth, dHeight,
     this._renderer._imageMode);
 
-  // Call the renderer with an object that contains the Image
-  // as an 'elt' property:
-  this._renderer.image({ elt: imgEl },
+  var canvas;
+  if (this._renderer._tint) {
+    // Just-in-time create/draw into a temp canvas so tinting can
+    // work within the renderer as it would for a p5.Image
+    this._tempCanvas = this._tempCanvas || document.createElement('canvas');
+    this._tempCanvas.width = imgEl.width;
+    this._tempCanvas.height = imgEl.height;
+    this._tempCanvas.getContext('2d').drawImage(imgEl, 0, 0);
+    canvas = this._tempCanvas;
+  }
+  // Call the renderer's image() method with an object that contains the Image
+  // as an 'elt' property and the temp canvas as well (when needed):
+  this._renderer.image({elt: imgEl, canvas: canvas},
     sx, sy, sWidth, sHeight, vals.x, vals.y, vals.w, vals.h);
 };
 
@@ -4406,7 +4416,7 @@ function Animation(pInst) {
             frame_info.x, frame_info.y,
             frame_info.width, frame_info.height,
             this.offX, this.offY,
-            frame_info.width, frame_info.height);  
+            frame_info.width, frame_info.height);
         } else {
           pInst.image(this.spriteSheet.image,
             frame_info.x, frame_info.y,
@@ -4737,10 +4747,10 @@ function SpriteSheet(pInst) {
       this._generateSheetFrames();
     }
   } else {
-      // When the final argument is present (either the 3rd or the 5th), it indicates
-      // whether we should load the URL as an Image element (as opposed to the default
-      // behavior, which is to load it as a p5.Image)
-      if (shortArgs) {
+    // When the final argument is present (either the 3rd or the 5th), it indicates
+    // whether we should load the URL as an Image element (as opposed to the default
+    // behavior, which is to load it as a p5.Image)
+    if (shortArgs) {
       if (spriteSheetArgs[2]) {
         this.image = pInst.loadImageElement(spriteSheetArgs[0]);
       } else {
@@ -4802,10 +4812,10 @@ function SpriteSheet(pInst) {
     }
     if (this.image instanceof Image) {
       pInst.imageElement(this.image, frameToDraw.frame.x, frameToDraw.frame.y,
-        frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);  
+        frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);
     } else {
       pInst.image(this.image, frameToDraw.frame.x, frameToDraw.frame.y,
-        frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);  
+        frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);
     }
   };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -400,6 +400,184 @@ p5.Vector.prototype.isParallel = function(v2, tolerance) {
 // =============================================================================
 
 /**
+ * Loads an image from a path and creates an Image from it.
+ * <br><br>
+ * The image may not be immediately available for rendering
+ * If you want to ensure that the image is ready before doing
+ * anything with it, place the loadImageElement() call in preload().
+ * You may also supply a callback function to handle the image when it's ready.
+ * <br><br>
+ * The path to the image should be relative to the HTML file
+ * that links in your sketch. Loading an from a URL or other
+ * remote location may be blocked due to your browser's built-in
+ * security.
+ *
+ * @method loadImageElement
+ * @param  {String} path Path of the image to be loaded
+ * @param  {Function(Image)} [successCallback] Function to be called once
+ *                                the image is loaded. Will be passed the
+ *                                Image.
+ * @param  {Function(Event)}    [failureCallback] called with event error if
+ *                                the image fails to load.
+ * @return {Image}                the Image object
+ */
+p5.prototype.loadImageElement = function(path, successCallback, failureCallback) {
+  var img = new Image();
+  var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
+
+  img.onload = function() {
+    if (typeof successCallback === 'function') {
+      successCallback(img);
+    }
+    if (decrementPreload && (successCallback !== decrementPreload)) {
+      decrementPreload();
+    }
+  };
+  img.onerror = function(e) {
+    p5._friendlyFileLoadError(0,img.src);
+    // don't get failure callback mixed up with decrementPreload
+    if ((typeof failureCallback === 'function') &&
+      (failureCallback !== decrementPreload)) {
+      failureCallback(e);
+    }
+  };
+
+  //set crossOrigin in case image is served which CORS headers
+  //this will let us draw to canvas without tainting it.
+  //see https://developer.mozilla.org/en-US/docs/HTML/CORS_Enabled_Image
+  // When using data-uris the file will be loaded locally
+  // so we don't need to worry about crossOrigin with base64 file types
+  if(path.indexOf('data:image/') !== 0) {
+    img.crossOrigin = 'Anonymous';
+  }
+
+  //start loading the image
+  img.src = path;
+
+  return img;
+};
+
+/**
+ * Draw an image element to the main canvas of the p5js sketch
+ *
+ * @method imageElement
+ * @param  {Image}    imgEl    the image to display
+ * @param  {Number}   [sx=0]   The X coordinate of the top left corner of the
+ *                             sub-rectangle of the source image to draw into
+ *                             the destination canvas.
+ * @param  {Number}   [sy=0]   The Y coordinate of the top left corner of the
+ *                             sub-rectangle of the source image to draw into
+ *                             the destination canvas.
+ * @param {Number} [sWidth=imgEl.width] The width of the sub-rectangle of the
+ *                                      source image to draw into the destination
+ *                                      canvas.
+ * @param {Number} [sHeight=imgEl.height] The height of the sub-rectangle of the
+ *                                        source image to draw into the
+ *                                        destination context.
+ * @param  {Number}   [dx=0]    The X coordinate in the destination canvas at
+ *                              which to place the top-left corner of the
+ *                              source image.
+ * @param  {Number}   [dy=0]    The Y coordinate in the destination canvas at
+ *                              which to place the top-left corner of the
+ *                              source image.
+ * @param  {Number}   [dWidth]  The width to draw the image in the destination
+ *                              canvas. This allows scaling of the drawn image.
+ * @param  {Number}   [dHeight] The height to draw the image in the destination
+ *                              canvas. This allows scaling of the drawn image.
+ * @example
+ * <div>
+ * <code>
+ * var imgEl;
+ * function preload() {
+ *   imgEl = loadImageElement("assets/laDefense.jpg");
+ * }
+ * function setup() {
+ *   imageElement(imgEl, 0, 0);
+ *   imageElement(imgEl, 0, 0, 100, 100);
+ *   imageElement(imgEl, 0, 0, 100, 100, 0, 0, 100, 100);
+ * }
+ * </code>
+ * </div>
+ * <div>
+ * <code>
+ * function setup() {
+ *   // here we use a callback to display the image after loading
+ *   loadImageElement("assets/laDefense.jpg", function(imgEl) {
+ *     imageElement(imgEl, 0, 0);
+ *   });
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * image of the underside of a white umbrella and grided ceiling above
+ * image of the underside of a white umbrella and grided ceiling above
+ *
+ */
+p5.prototype.imageElement = function(imgEl, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
+  /**
+   * Validates clipping params. Per drawImage spec sWidth and sHight cannot be
+   * negative or greater than image intrinsic width and height
+   * @private
+   * @param {Number} sVal
+   * @param {Number} iVal
+   * @returns {Number}
+   * @private
+   */
+  function _sAssign(sVal, iVal) {
+    if (sVal > 0 && sVal < iVal) {
+      return sVal;
+    }
+    else {
+      return iVal;
+    }
+  }
+
+  function modeAdjust(a, b, c, d, mode) {
+    if (mode === p5.prototype.CORNER) {
+      return { x: a, y: b, w: c, h: d };
+    } else if (mode === p5.prototype.CORNERS) {
+      return { x: a, y: b, w: c-a, h: d-b };
+    } else if (mode === p5.prototype.RADIUS) {
+      return { x: a-c, y: b-d, w: 2*c, h: 2*d };
+    } else if (mode === p5.prototype.CENTER) {
+      return { x: a-c*0.5, y: b-d*0.5, w: c, h: d };
+    }
+  }
+  
+  if (arguments.length <= 5) {
+    dx = sx || 0;
+    dy = sy || 0;
+    sx = 0;
+    sy = 0;
+    dWidth = sWidth || imgEl.width;
+    dHeight = sHeight || imgEl.height;
+    sWidth = imgEl.width;
+    sHeight = imgEl.height;
+  } else if (arguments.length === 9) {
+    sx = sx || 0;
+    sy = sy || 0;
+    sWidth = _sAssign(sWidth, imgEl.width);
+    sHeight = _sAssign(sHeight, imgEl.height);
+
+    dx = dx || 0;
+    dy = dy || 0;
+    dWidth = dWidth || imgEl.width;
+    dHeight = dHeight || imgEl.height;
+  } else {
+    throw 'Wrong number of arguments to imageElement()';
+  }
+
+  var vals = modeAdjust(dx, dy, dWidth, dHeight,
+    this._renderer._imageMode);
+
+  // Call the renderer with an object that contains the Image
+  // as an 'elt' property:
+  this._renderer.image({ elt: imgEl },
+    sx, sy, sWidth, sHeight, vals.x, vals.y, vals.w, vals.h);
+};
+
+/**
 * A Group containing all the sprites in the sketch.
 *
 * @property allSprites
@@ -4223,13 +4401,25 @@ function Animation(pInst) {
       }
 
       if (frame_info) {
-        pInst.image(this.spriteSheet.image,
-          frame_info.x, frame_info.y,
-          frame_info.width, frame_info.height,
-          this.offX, this.offY,
-          frame_info.width, frame_info.height);
+        if (this.spriteSheet.image instanceof Image) {
+          pInst.imageElement(this.spriteSheet.image,
+            frame_info.x, frame_info.y,
+            frame_info.width, frame_info.height,
+            this.offX, this.offY,
+            frame_info.width, frame_info.height);  
+        } else {
+          pInst.image(this.spriteSheet.image,
+            frame_info.x, frame_info.y,
+            frame_info.width, frame_info.height,
+            this.offX, this.offY,
+            frame_info.width, frame_info.height);
+          }
       } else if (image) {
-        pInst.image(image, this.offX, this.offY);
+        if (image instanceof Image) {
+          pInst.imageElement(image, this.offX, this.offY);
+        } else {
+          pInst.image(image, this.offX, this.offY);
+        }
       } else {
         pInst.print('Warning undefined frame '+frame);
         //this.isActive = false;
@@ -4526,10 +4716,13 @@ function SpriteSheet(pInst) {
     }
   };
 
-  if (spriteSheetArgs.length === 2 && Array.isArray(spriteSheetArgs[1])) {
+  var shortArgs = spriteSheetArgs.length === 2 || spriteSheetArgs.length === 3;
+  var longArgs = spriteSheetArgs.length === 4 || spriteSheetArgs.length === 5;
+
+  if (shortArgs && Array.isArray(spriteSheetArgs[1])) {
     this.frames = spriteSheetArgs[1];
     this.num_frames = this.frames.length;
-  } else if (spriteSheetArgs.length === 4 &&
+  } else if (longArgs &&
     (typeof spriteSheetArgs[1] === 'number') &&
     (typeof spriteSheetArgs[2] === 'number') &&
     (typeof spriteSheetArgs[3] === 'number')) {
@@ -4538,16 +4731,27 @@ function SpriteSheet(pInst) {
     this.num_frames = spriteSheetArgs[3];
   }
 
-  if(spriteSheetArgs[0] instanceof p5.Image) {
+  if(spriteSheetArgs[0] instanceof p5.Image || spriteSheetArgs[0] instanceof Image) {
     this.image = spriteSheetArgs[0];
     if (spriteSheetArgs.length === 4) {
       this._generateSheetFrames();
     }
   } else {
-    if (spriteSheetArgs.length === 2) {
-      this.image = pInst.loadImage(spriteSheetArgs[0]);
-    } else if (spriteSheetArgs.length === 4) {
-      this.image = pInst.loadImage(spriteSheetArgs[0], this._generateSheetFrames.bind(this));
+      // When the final argument is present (either the 3rd or the 5th), it indicates
+      // whether we should load the URL as an Image element (as opposed to the default
+      // behavior, which is to load it as a p5.Image)
+      if (shortArgs) {
+      if (spriteSheetArgs[2]) {
+        this.image = pInst.loadImageElement(spriteSheetArgs[0]);
+      } else {
+        this.image = pInst.loadImage(spriteSheetArgs[0]);
+      }
+    } else if (longArgs) {
+      if (spriteSheetArgs[4]) {
+        this.image = pInst.loadImageElement(spriteSheetArgs[0], this._generateSheetFrames.bind(this));
+      } else {
+        this.image = pInst.loadImage(spriteSheetArgs[0], this._generateSheetFrames.bind(this));
+      }
     }
   }
 
@@ -4596,8 +4800,13 @@ function SpriteSheet(pInst) {
         y += frameToDraw.spriteSourceSize.y;
       }
     }
-    pInst.image(this.image, frameToDraw.frame.x, frameToDraw.frame.y,
-      frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);
+    if (this.image instanceof Image) {
+      pInst.imageElement(this.image, frameToDraw.frame.x, frameToDraw.frame.y,
+        frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);  
+    } else {
+      pInst.image(this.image, frameToDraw.frame.x, frameToDraw.frame.y,
+        frameToDraw.frame.width, frameToDraw.frame.height, x, y, dWidth, dHeight);  
+    }
   };
 
   /**
@@ -4992,6 +5201,8 @@ p5.prototype.registerMethod('post', updateTree);
 //camera push and pop
 p5.prototype.registerMethod('pre', cameraPush);
 p5.prototype.registerMethod('post', cameraPop);
+
+p5.prototype.registerPreloadMethod('loadImageElement', p5.prototype);
 
 //deltaTime
 //p5.prototype.registerMethod('pre', updateDelta);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/p5.play",
-  "version": "1.3.3-cdo",
+  "version": "1.3.4-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
* Safari has placed a limit on the total amount of memory allocated to canvases. This is particularly problematic on iOS 12 when you load a lot of `SpriteSheet` objects. `SpriteSheet` required a `p5.Image` to be loaded for each image. `p5.Image` creates and maintains a canvas for each image.
* Added new p5 extensions `loadImageElement()` and `imageElement()` that load and draw an `Image` element respectively, just like `loadImage()` and `image()` do for `p5.Image`
* Modified `SpriteSheet` and `loadSpriteSheet()` in `p5.play.js` so they can work with `this.image` as either a `p5.Image` or a native `Image` element. A new additional parameter to `loadSpriteSheet()` or the `SpriteSheet` constructor is an optional boolean indicating whether we want to load the image as an `Image` element instead of a `p5.Image`