### PR TITLE
loadSpriteSheet() image mode can take a callback

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4752,16 +4752,16 @@ function SpriteSheet(pInst) {
     // behavior, which is to load it as a p5.Image). If that argument is a function,
     // it will be called back once the load succeeds or fails. On success, the Image
     // will be supplied as the only parameter. On failure, null will be supplied.
+    var callback;
     if (shortArgs) {
       if (spriteSheetArgs[2]) {
-        let callback;
         if (typeof spriteSheetArgs[2] === 'function') {
           callback = spriteSheetArgs[2];
         }
         this.image = pInst.loadImageElement(
           spriteSheetArgs[0],
-          function (img) { callback && callback(img); },
-          function () { callback && callback(null); }
+          function(img) { if (callback) return callback(img); },
+          function() { if (callback) return callback(null); }
         );
       } else {
         this.image = pInst.loadImage(spriteSheetArgs[0]);
@@ -4769,17 +4769,16 @@ function SpriteSheet(pInst) {
     } else if (longArgs) {
       var generateSheetFrames = this._generateSheetFrames.bind(this);
       if (spriteSheetArgs[4]) {
-        let callback;
         if (typeof spriteSheetArgs[4] === 'function') {
           callback = spriteSheetArgs[4];
         }
         this.image = pInst.loadImageElement(
           spriteSheetArgs[0],
-          function (img) {
+          function(img) {
             generateSheetFrames(img);
-            callback && callback(img);
+            if (callback) return callback(img);
           },
-          function () { callback && callback(null); }
+          function() { if (callback) return callback(null); }
         );
       } else {
         this.image = pInst.loadImage(spriteSheetArgs[0], generateSheetFrames);

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4749,18 +4749,40 @@ function SpriteSheet(pInst) {
   } else {
     // When the final argument is present (either the 3rd or the 5th), it indicates
     // whether we should load the URL as an Image element (as opposed to the default
-    // behavior, which is to load it as a p5.Image)
+    // behavior, which is to load it as a p5.Image). If that argument is a function,
+    // it will be called back once the load succeeds or fails. On success, the Image
+    // will be supplied as the only parameter. On failure, null will be supplied.
     if (shortArgs) {
       if (spriteSheetArgs[2]) {
-        this.image = pInst.loadImageElement(spriteSheetArgs[0]);
+        let callback;
+        if (typeof spriteSheetArgs[2] === 'function') {
+          callback = spriteSheetArgs[2];
+        }
+        this.image = pInst.loadImageElement(
+          spriteSheetArgs[0],
+          function (img) { callback && callback(img); },
+          function () { callback && callback(null); }
+        );
       } else {
         this.image = pInst.loadImage(spriteSheetArgs[0]);
       }
     } else if (longArgs) {
+      var generateSheetFrames = this._generateSheetFrames.bind(this);
       if (spriteSheetArgs[4]) {
-        this.image = pInst.loadImageElement(spriteSheetArgs[0], this._generateSheetFrames.bind(this));
+        let callback;
+        if (typeof spriteSheetArgs[4] === 'function') {
+          callback = spriteSheetArgs[4];
+        }
+        this.image = pInst.loadImageElement(
+          spriteSheetArgs[0],
+          function (img) {
+            generateSheetFrames(img);
+            callback && callback(img);
+          },
+          function () { callback && callback(null); }
+        );
       } else {
-        this.image = pInst.loadImage(spriteSheetArgs[0], this._generateSheetFrames.bind(this));
+        this.image = pInst.loadImage(spriteSheetArgs[0], generateSheetFrames);
       }
     }
   }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4743,7 +4743,7 @@ function SpriteSheet(pInst) {
 
   if(spriteSheetArgs[0] instanceof p5.Image || spriteSheetArgs[0] instanceof Image) {
     this.image = spriteSheetArgs[0];
-    if (spriteSheetArgs.length === 4) {
+    if (longArgs) {
       this._generateSheetFrames();
     }
   } else {


### PR DESCRIPTION
* Recently we added the ability to instantiate a `SpriteSheet` in such a way that we wanted it to create a `Image` element vs. a `p5.Image` object. The syntax was to add a `boolean` parameter and pass `true`. In order to support the mode of doing this outside of the `preload` function, I've changed that optional parameter to accept either a `boolean` or a `function`. If it is a `function`, we still interpret the meaning as a request to create an `Image` element vs a `p5.Image` object, but we also use that function as a callback, which will be called with the `Image` element as its only parameter (upon successful `Image` and `SpriteSheet` load) or with `null` if the `Image` load failed.

Examples:
``p5.loadSpriteSheet(url, frames, img => { console.log(`Image callback: ${img}`); });``
``p5.loadSpriteSheet(url, width, height, numFrames, img => { console.log(`Image callback: ${img}`); });``