### PR TITLE
Smaller temporary canvas for tint

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -71,8 +71,6 @@ p5.prototype.registerMethod('init', function p5PlayInit() {
   // Temporary canvas for supporting tint operations from image elements;
   // see p5.prototype.imageElement()
   this._tempCanvas = document.createElement('canvas');
-  this._tempContext = this._tempCanvas.getContext('2d');
-  this._tempFauxImage = {elt: null, canvas: null};
 });
 
 // This provides a way for us to lazily define properties that
@@ -581,26 +579,25 @@ p5.prototype.imageElement = function(imgEl, sx, sy, sWidth, sHeight, dx, dy, dWi
     // Just-in-time create/draw into a temp canvas so tinting can
     // work within the renderer as it would for a p5.Image
     // Only resize canvas if it's too small
+    var context = this._tempCanvas.getContext('2d');
     if (this._tempCanvas.width < vals.w || this._tempCanvas.height < vals.h) {
       this._tempCanvas.width = Math.max(this._tempCanvas.width, vals.w);
       this._tempCanvas.height = Math.max(this._tempCanvas.height, vals.h);
     } else {
-      this._tempContext.clearRect(0, 0, vals.w, vals.h);
+      context.clearRect(0, 0, vals.w, vals.h);
     }
-    this._tempFauxImage.canvas = this._tempCanvas;
-    this._tempContext.drawImage(imgEl,
+    context.drawImage(imgEl,
       sx, sy, sWidth, sHeight,
       0, 0, vals.w, vals.h);
     // Call the renderer's image() method with an object that contains the Image
     // as an 'elt' property and the temp canvas as well (when needed):
-    this._renderer.image(this._tempFauxImage,
+    this._renderer.image({canvas: this._tempCanvas},
       0, 0, vals.w, vals.h,
       vals.x, vals.y, vals.w, vals.h);
   } else {
-    this._tempFauxImage.elt = imgEl;
-    this._tempFauxImage.canvas = null;
-    this._renderer.image(this._tempFauxImage,
-      sx, sy, sWidth, sHeight, vals.x, vals.y, vals.w, vals.h);
+    this._renderer.image({elt: imgEl},
+      sx, sy, sWidth, sHeight,
+      vals.x, vals.y, vals.w, vals.h);
   }
 };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -67,6 +67,12 @@ p5.prototype.registerMethod('init', function p5PlayInit() {
 
   var startDate = new Date();
   this._startTime = startDate.getTime();
+
+  // Temporary canvas for supporting tint operations from image elements;
+  // see p5.prototype.imageElement()
+  this._tempCanvas = document.createElement('canvas');
+  this._tempContext = this._tempCanvas.getContext('2d');
+  this._tempFauxImage = {elt: null, canvas: null};
 });
 
 // This provides a way for us to lazily define properties that
@@ -571,20 +577,31 @@ p5.prototype.imageElement = function(imgEl, sx, sy, sWidth, sHeight, dx, dy, dWi
   var vals = modeAdjust(dx, dy, dWidth, dHeight,
     this._renderer._imageMode);
 
-  var canvas;
   if (this._renderer._tint) {
     // Just-in-time create/draw into a temp canvas so tinting can
     // work within the renderer as it would for a p5.Image
-    this._tempCanvas = this._tempCanvas || document.createElement('canvas');
-    this._tempCanvas.width = imgEl.width;
-    this._tempCanvas.height = imgEl.height;
-    this._tempCanvas.getContext('2d').drawImage(imgEl, 0, 0);
-    canvas = this._tempCanvas;
+    // Only resize canvas if it's too small
+    if (this._tempCanvas.width < vals.w || this._tempCanvas.height < vals.h) {
+      this._tempCanvas.width = Math.max(this._tempCanvas.width, vals.w);
+      this._tempCanvas.height = Math.max(this._tempCanvas.height, vals.h);
+    } else {
+      this._tempContext.clearRect(0, 0, vals.w, vals.h);
+    }
+    this._tempFauxImage.canvas = this._tempCanvas;
+    this._tempContext.drawImage(imgEl,
+      sx, sy, sWidth, sHeight,
+      0, 0, vals.w, vals.h);
+    // Call the renderer's image() method with an object that contains the Image
+    // as an 'elt' property and the temp canvas as well (when needed):
+    this._renderer.image(this._tempFauxImage,
+      0, 0, vals.w, vals.h,
+      vals.x, vals.y, vals.w, vals.h);
+  } else {
+    this._tempFauxImage.elt = imgEl;
+    this._tempFauxImage.canvas = null;
+    this._renderer.image(this._tempFauxImage,
+      sx, sy, sWidth, sHeight, vals.x, vals.y, vals.w, vals.h);
   }
-  // Call the renderer's image() method with an object that contains the Image
-  // as an 'elt' property and the temp canvas as well (when needed):
-  this._renderer.image({elt: imgEl, canvas: canvas},
-    sx, sy, sWidth, sHeight, vals.x, vals.y, vals.w, vals.h);
 };
 
 /**


### PR DESCRIPTION
I noticed while checking out the performance characteristics of the [new packed spritesheets](https://github.com/code-dot-org/dance-party/pull/241) that when we've got a tint applied to a sprite we're copying to a temporary canvas the size of the spritesheet (now up to 3Mpx in our case).  This seemed inefficient to me, so now the temporary canvas only grows to the size of the largest individual frame you copy.

## Results

Tested atop my combined spritesheet changes in https://github.com/code-dot-org/dance-party/pull/241, running 132 unique animations running simultaneously with a tint applied to all of them (this console script):

```js
(function degenerateCase() {
  for (let cIndex = 0; cIndex < 11; cIndex++) {
    for (let move = 0; move < 12; move++) {
      const character = nativeAPI.world.SPRITE_NAMES[cIndex];
      const sprite = nativeAPI.makeNewDanceSprite(character, null, {
        x: 20 + 20 * move,
        y: 140 + 20 * cIndex,
      });
      nativeAPI.setProp(sprite, 'scale', 10);
      nativeAPI.changeMoveLR(sprite, move, 1);
    }
  }
  nativeAPI.setTintEach('all', 100);
}())
```

### Before
1500ms per frame, ~350% CPU load.
![image](https://user-images.githubusercontent.com/1615761/48316198-33fe6d00-e595-11e8-86d2-2a6a3f56b640.png)


### After
500ms per frame, ~50% CPU load.
![image](https://user-images.githubusercontent.com/1615761/48316183-fe598400-e594-11e8-951b-cc1d718e2f2b.png)
