### PR TITLE
Scale Alpha Tint

### DIFF
--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13493,7 +13493,7 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
 
   // this._tint stores rgba values on scale form 0-255. To set fillStyle with
   // 'rgba', the alpha needs to be on a 0 to 1 scale.
-  let rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
+  var rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
   tmpCtx.fillStyle = 'rgba(' + rgba + ')';
   tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
   tmpCtx.globalCompositeOperation = 'destination-atop';

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -6401,7 +6401,7 @@ exports.sizeOf = sizeOf;
 
     function timedOut() {
       self._timedOut = true
-      self.request.abort()      
+      self.request.abort()
     }
 
     function error(resp, msg, t) {
@@ -13491,7 +13491,10 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   this._tintCanvas.height = img.canvas.height;
   var tmpCtx = this._tintCanvas.getContext('2d');
 
-  tmpCtx.fillStyle = 'rgba(' + this._tint.join(', ') + ')';
+  // this._tint stores rgba values on scale form 0-255. To set fillStyle with
+  // 'rgba', the alpha needs to be on a 0 to 1 scale.
+  let rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
+  tmpCtx.fillStyle = 'rgba(' + rgba + ')';
   tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
   tmpCtx.globalCompositeOperation = 'destination-atop';
   tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,


### PR DESCRIPTION
Change already added to P5.js, adding here to keep the libraries the same.

Basically, this change was because we were using the this._tint value to set the tint canvas fill. The alpha in this._tint was saved on a scale of 0 to 255, but the value on the tint canvas fill needed to be between 0 and 1. So I added extra logic to adjust the scale as necessary. 