### PR TITLE
Update P5 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@code-dot-org/p5.play",
   "version": "1.3.12-cdo",
-  "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learnpillowing environment.",
+  "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {
     "@code-dot-org/p5": "0.5.4-cdo.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@code-dot-org/p5.play",
   "version": "1.3.12-cdo",
-  "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
+  "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learnpillowing environment.",
   "dependencies": {
-    "@code-dot-org/p5": "0.5.4-cdo.4"
+    "@code-dot-org/p5": "0.5.4-cdo.5"
   },
   "devDependencies": {
     "eslint": "^3.1.0",


### PR DESCRIPTION
Published a new version of P5 to fix the tint issue, outlined here: https://github.com/code-dot-org/p5.play


Future work will be to publish a new version of this repo and add it to the Code.org repo.
