### PR TITLE
Alpha in Example Lib

### DIFF
--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13494,12 +13494,13 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   var tmpCtx = this._tintCanvas.getContext('2d');
 
   // Special case of 'white tint' which affects only transparency - default to P5.prototype
-  // of tint. Otherwise, use code-dot-org specific behavior where tint only affects the RGB
+  // tint. Otherwise, use code-dot-org specific behavior where tint only affects the RGB
   // of the sprite and the alpha of tint changes the 'strength' of the tint.
-  if (this._tint[0] === 255 && this._tint[1] === 255 && this._tint[2] === 255) {
-    // Set the p5 renderer tint to the current tint value
+  if (this._transparency) {
+    // Set the p5 renderer tint to the current tint value.
+    // Transparency stored as value between 0 to 1, but tint is stored as value between 0 and 255.
     p5.prototype._renderer = {};
-    p5.prototype._renderer._tint = this._tint;
+    p5.prototype._renderer._tint = [255, 255, 255, this._transparency * 255];
     return p5.prototype._getTintedImageCanvas(img);
   } else {
     // this._tint stores rgba values on scale form 0-255. To set fillStyle with

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13486,23 +13486,36 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   if (!img.canvas) {
     return img;
   }
+
+
   this._tintCanvas = this._tintCanvas || document.createElement('canvas');
   this._tintCanvas.width = img.canvas.width;
   this._tintCanvas.height = img.canvas.height;
   var tmpCtx = this._tintCanvas.getContext('2d');
 
-  // this._tint stores rgba values on scale form 0-255. To set fillStyle with
-  // 'rgba', the alpha needs to be on a 0 to 1 scale.
-  var rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
-  tmpCtx.fillStyle = 'rgba(' + rgba + ')';
-  tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
-  tmpCtx.globalCompositeOperation = 'destination-atop';
-  tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
-    this._tintCanvas.height);
-  tmpCtx.globalCompositeOperation = 'multiply';
-  tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
-    this._tintCanvas.height);
-  return this._tintCanvas;
+  // Special case of 'white tint' which affects only transparency - default to P5.prototype
+  // of tint. Otherwise, use code-dot-org specific behavior where tint only affects the RGB
+  // of the sprite and the alpha of tint changes the 'strength' of the tint.
+  if (this._tint[0] === 255 && this._tint[1] === 255 && this._tint[2] === 255) {
+    // Set the p5 renderer tint to the current tint value
+    p5.prototype._renderer = {};
+    p5.prototype._renderer._tint = this._tint;
+    return p5.prototype._getTintedImageCanvas(img);
+  } else {
+    // this._tint stores rgba values on scale form 0-255. To set fillStyle with
+    // 'rgba', the alpha needs to be on a 0 to 1 scale.
+    var rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
+    tmpCtx.fillStyle = 'rgba(' + rgba + ')';
+    tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
+    tmpCtx.globalCompositeOperation = 'destination-atop';
+    tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
+      this._tintCanvas.height);
+    tmpCtx.globalCompositeOperation = 'multiply';
+    tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
+      this._tintCanvas.height);
+    return this._tintCanvas;
+  }
+
 };
 
 

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13499,24 +13499,22 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   if (this._alpha) {
     // Set the p5 renderer tint to the current tint value.
     // Alpha stored as value between 0 to 1, but tint is stored as value between 0 and 255.
-    p5.prototype._renderer = {};
-    p5.prototype._renderer._tint = [255, 255, 255, this._alpha * 255];
+    p5.prototype._renderer = p5.prototype._renderer || {};
+    p5.prototype._renderer._tint = [255, 255, 255, Math.round(this._alpha * 255)];
     return p5.prototype._getTintedImageCanvas(img);
-  } else {
-    // this._tint stores rgba values on scale form 0-255. To set fillStyle with
-    // 'rgba', the alpha needs to be on a 0 to 1 scale.
-    var rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
-    tmpCtx.fillStyle = 'rgba(' + rgba + ')';
-    tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
-    tmpCtx.globalCompositeOperation = 'destination-atop';
-    tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
-      this._tintCanvas.height);
-    tmpCtx.globalCompositeOperation = 'multiply';
-    tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
-      this._tintCanvas.height);
-    return this._tintCanvas;
   }
-
+  // this._tint stores rgba values on scale form 0-255. To set fillStyle with
+  // 'rgba', the alpha needs to be on a 0 to 1 scale.
+  var rgba = this._tint.slice(0,3).join(',') + ", " + this._tint[3] / 255;
+  tmpCtx.fillStyle = 'rgba(' + rgba + ')';
+  tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
+  tmpCtx.globalCompositeOperation = 'destination-atop';
+  tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
+    this._tintCanvas.height);
+  tmpCtx.globalCompositeOperation = 'multiply';
+  tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,
+    this._tintCanvas.height);
+  return this._tintCanvas;
 };
 
 

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13205,7 +13205,7 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._imageMode = constants.CORNER;
 
   this._tint = null;
-  this._transparency = null;
+  this._alpha = null;
   this._doStroke = true;
   this._doFill = true;
   this._strokeSet = false;
@@ -13463,7 +13463,7 @@ p5.Renderer2D.prototype.image =
   function (img, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
   var cnv;
   try {
-    if (this._tint || this._transparency) {
+    if (this._tint || this._alpha) {
       if (p5.MediaElement && img instanceof p5.MediaElement) {
         img.loadPixels();
       }
@@ -13493,14 +13493,14 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   this._tintCanvas.height = img.canvas.height;
   var tmpCtx = this._tintCanvas.getContext('2d');
 
-  // Special case of 'white tint' which affects only transparency - default to P5.prototype
+  // Special case of 'white tint' which affects only alpha - default to P5.prototype
   // tint. Otherwise, use code-dot-org specific behavior where tint only affects the RGB
   // of the sprite and the alpha of tint changes the 'strength' of the tint.
-  if (this._transparency) {
+  if (this._alpha) {
     // Set the p5 renderer tint to the current tint value.
-    // Transparency stored as value between 0 to 1, but tint is stored as value between 0 and 255.
+    // Alpha stored as value between 0 to 1, but tint is stored as value between 0 and 255.
     p5.prototype._renderer = {};
-    p5.prototype._renderer._tint = [255, 255, 255, this._transparency * 255];
+    p5.prototype._renderer._tint = [255, 255, 255, this._alpha * 255];
     return p5.prototype._getTintedImageCanvas(img);
   } else {
     // this._tint stores rgba values on scale form 0-255. To set fillStyle with
@@ -15249,7 +15249,7 @@ p5.prototype.push = function () {
     _doFill: this._renderer._doFill,
     _fillSet: this._renderer._fillSet,
     _tint: this._renderer._tint,
-    _transparency: this._renderer._transparency,
+    _alpha: this._renderer._alpha,
     _imageMode: this._renderer._imageMode,
     _rectMode: this._renderer._rectMode,
     _ellipseMode: this._renderer._ellipseMode,
@@ -19923,8 +19923,8 @@ p5.prototype.tint = function () {
   this._renderer._tint = c.levels;
 };
 
-p5.prototype.transparency = function () {
-  this._renderer._transparency = arguments[0];
+p5.prototype.alpha = function () {
+  this._renderer._alpha = arguments[0];
 };
 
 /**

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13205,6 +13205,7 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._imageMode = constants.CORNER;
 
   this._tint = null;
+  this._transparency = null;
   this._doStroke = true;
   this._doFill = true;
   this._strokeSet = false;
@@ -13462,7 +13463,7 @@ p5.Renderer2D.prototype.image =
   function (img, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
   var cnv;
   try {
-    if (this._tint) {
+    if (this._tint || this._transparency) {
       if (p5.MediaElement && img instanceof p5.MediaElement) {
         img.loadPixels();
       }
@@ -13486,7 +13487,6 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   if (!img.canvas) {
     return img;
   }
-
 
   this._tintCanvas = this._tintCanvas || document.createElement('canvas');
   this._tintCanvas.width = img.canvas.width;
@@ -15248,6 +15248,7 @@ p5.prototype.push = function () {
     _doFill: this._renderer._doFill,
     _fillSet: this._renderer._fillSet,
     _tint: this._renderer._tint,
+    _transparency: this._renderer._transparency,
     _imageMode: this._renderer._imageMode,
     _rectMode: this._renderer._rectMode,
     _ellipseMode: this._renderer._ellipseMode,
@@ -19919,6 +19920,10 @@ p5.prototype.image =
 p5.prototype.tint = function () {
   var c = this.color.apply(this, arguments);
   this._renderer._tint = c.levels;
+};
+
+p5.prototype.transparency = function () {
+  this._renderer._transparency = arguments[0];
 };
 
 /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1444,6 +1444,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var pop = pInstBind('pop');
   var colorMode = pInstBind('colorMode');
   var tint = pInstBind('tint');
+  var transparency = pInstBind('transparency');
   var lerpColor = pInstBind('lerpColor');
   var noStroke = pInstBind('noStroke');
   var rectMode = pInstBind('rectMode');
@@ -2507,7 +2508,14 @@ function Sprite(pInst, _x, _y, _w, _h) {
           push();
           tint(this.tint);
         }
+        if(this.transparency) {
+          push();
+          transparency(this.transparency);
+        }
         animations[currentAnimation].draw(0, 0, 0);
+        if(this.transparency) {
+          pop();
+        }
         if(this.tint) {
           pop();
         }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1444,7 +1444,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var pop = pInstBind('pop');
   var colorMode = pInstBind('colorMode');
   var tint = pInstBind('tint');
-  var transparency = pInstBind('transparency');
+  var alpha = pInstBind('alpha');
   var lerpColor = pInstBind('lerpColor');
   var noStroke = pInstBind('noStroke');
   var rectMode = pInstBind('rectMode');
@@ -2508,12 +2508,12 @@ function Sprite(pInst, _x, _y, _w, _h) {
           push();
           tint(this.tint);
         }
-        if(this.transparency) {
+        if(this.alpha) {
           push();
-          transparency(this.transparency);
+          alpha(this.alpha);
         }
         animations[currentAnimation].draw(0, 0, 0);
-        if(this.transparency) {
+        if(this.alpha) {
           pop();
         }
         if(this.tint) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.14-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {
-    "@code-dot-org/p5": "0.5.4-cdo.6"
+    "@code-dot-org/p5": "0.5.4-cdo.7"
   },
   "devDependencies": {
     "eslint": "^3.1.0",


### PR DESCRIPTION
Add an alpha property in the example library to allow changes to sprite transparency. Includes a bump to latest p5.js which should include these changes as well.

Gif shows functionality, before switch from 'transparency' terminology to 'alpha' terminology.

![transparency](https://user-images.githubusercontent.com/2959170/114241891-cbbb3d80-993e-11eb-9f2c-5620dc006ea0.gif)
