### PR TITLE
Alpha Tint Fix

### DIFF
--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -19924,8 +19924,8 @@ p5.prototype.tint = function () {
 /**
  * Sets the alpha value on the renderer which can be used in a tint special
  * case to change the opacity of the sprite
-  @method alphaTint
-  @param {Number} alpha  opacity of the sprite
+ * @method alphaTint
+ * @param {Number} alpha  opacity of the sprite
  */
 p5.prototype.alphaTint = function () {
   this._renderer._alpha = arguments[0];

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -19921,7 +19921,7 @@ p5.prototype.tint = function () {
   this._renderer._tint = c.levels;
 };
 
-p5.prototype.alpha = function () {
+p5.prototype.alphaTint = function () {
   this._renderer._alpha = arguments[0];
 };
 

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -19921,6 +19921,12 @@ p5.prototype.tint = function () {
   this._renderer._tint = c.levels;
 };
 
+/**
+ * Sets the alpha value on the renderer which can be used in a tint special
+ * case to change the opacity of the sprite
+  @method alphaTint
+  @param {Number} alpha  opacity of the sprite
+ */
 p5.prototype.alphaTint = function () {
   this._renderer._alpha = arguments[0];
 };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1444,7 +1444,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var pop = pInstBind('pop');
   var colorMode = pInstBind('colorMode');
   var tint = pInstBind('tint');
-  var alpha = pInstBind('alpha');
+  var alphaTint = pInstBind('alphaTint');
   var lerpColor = pInstBind('lerpColor');
   var noStroke = pInstBind('noStroke');
   var rectMode = pInstBind('rectMode');
@@ -2510,7 +2510,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
         }
         if(this.alpha) {
           push();
-          alpha(this.alpha);
+          alphaTint(this.alpha);
         }
         animations[currentAnimation].draw(0, 0, 0);
         if(this.alpha) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@code-dot-org/p5": {
-      "version": "0.5.4-cdo.7",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/p5/-/p5-0.5.4-cdo.7.tgz",
-      "integrity": "sha512-hw4r1oI0qOWb+hZruB/hPD/ZFF5UZPp2ARrvzmITXx+/CsLM14TuHLh79N6ZJnq2CTpzIoWiPPAMGgJhYzPN7w==",
+      "version": "0.5.4-cdo.8",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/p5/-/p5-0.5.4-cdo.8.tgz",
+      "integrity": "sha512-+Uc3vWEivYLq1Wkkl8EBXrtPCp3VGd6Aar1+XwClRgdlX1KqlRSZR3SUGKFhn17NWQzr3TymmdwtP4LAo8ymJw==",
       "requires": {
         "opentype.js": "^0.4.9",
         "reqwest": "^1.1.5"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.15-cdo",
   "description": "Code.org fork of molleindustria/p5.play for use within the Code Studio learning environment.",
   "dependencies": {
-    "@code-dot-org/p5": "0.5.4-cdo.7"
+    "@code-dot-org/p5": "0.5.4-cdo.8"
   },
   "devDependencies": {
     "eslint": "^3.1.0",


### PR DESCRIPTION
:facepalm: Turns out there are two p5.prototype.alpha functions and when we import the transparency fix into cdo, cdo uses the other alpha function. Changing the name of the newly added alpha function to be AlphaTint to differentiate the two functions.