### PR TITLE
Better optional parameter checks

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -171,8 +171,8 @@ if (!p5.prototype.originalCreateCanvas_) {
 if (!p5.prototype.originalEllipse_) {
   p5.prototype.originalEllipse_ = p5.prototype.ellipse;
   p5.prototype.ellipse = function(x, y, w, h) {
-    w = (w) ? w : 50;
-    h = (w && !h) ? w : h;
+    w = (w === undefined) ? 50 : w;
+    h = (h === undefined) ? w : h;
     this.originalEllipse_(x, y, w, h);
   };
 }
@@ -182,8 +182,8 @@ if (!p5.prototype.originalEllipse_) {
 if (!p5.prototype.originalRect_) {
   p5.prototype.originalRect_ = p5.prototype.rect;
   p5.prototype.rect = function(x, y, w, h) {
-    w = (w) ? w : 50;
-    h = (w && !h) ? w : h;
+    w = (w === undefined) ? 50 : w;
+    h = (h === undefined) ? w : h;
     this.originalRect_(x, y, w, h);
   };
 }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -171,8 +171,8 @@ if (!p5.prototype.originalCreateCanvas_) {
 if (!p5.prototype.originalEllipse_) {
   p5.prototype.originalEllipse_ = p5.prototype.ellipse;
   p5.prototype.ellipse = function(x, y, w, h) {
-    w = (w == undefined) ? 50 : w;
-    h = (h == undefined) ? w : h;
+    w = (w === undefined) ? 50 : w;
+    h = (h === undefined) ? w : h;
     this.originalEllipse_(x, y, w, h);
   };
 }
@@ -182,8 +182,8 @@ if (!p5.prototype.originalEllipse_) {
 if (!p5.prototype.originalRect_) {
   p5.prototype.originalRect_ = p5.prototype.rect;
   p5.prototype.rect = function(x, y, w, h) {
-    w = (w == undefined) ? 50 : w;
-    h = (h == undefined) ? w : h;
+    w = (w === undefined) ? 50 : w;
+    h = (h === undefined) ? w : h;
     this.originalRect_(x, y, w, h);
   };
 }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -171,8 +171,8 @@ if (!p5.prototype.originalCreateCanvas_) {
 if (!p5.prototype.originalEllipse_) {
   p5.prototype.originalEllipse_ = p5.prototype.ellipse;
   p5.prototype.ellipse = function(x, y, w, h) {
-    w = (w === undefined) ? 50 : w;
-    h = (h === undefined) ? w : h;
+    w = (w == undefined) ? 50 : w;
+    h = (h == undefined) ? w : h;
     this.originalEllipse_(x, y, w, h);
   };
 }
@@ -182,8 +182,8 @@ if (!p5.prototype.originalEllipse_) {
 if (!p5.prototype.originalRect_) {
   p5.prototype.originalRect_ = p5.prototype.rect;
   p5.prototype.rect = function(x, y, w, h) {
-    w = (w === undefined) ? 50 : w;
-    h = (h === undefined) ? w : h;
+    w = (w == undefined) ? 50 : w;
+    h = (h == undefined) ? w : h;
     this.originalRect_(x, y, w, h);
   };
 }


### PR DESCRIPTION
We should only set optional parameters if the arguments are not passed in (undefined).
Right now, they just check whether the arguments are truthy, so if you explicitly pass in 0, it gets overridden with the default value.

context in slack thread: https://codedotorg.slack.com/archives/CN4T89YP8/p1620090146043300