### PR TITLE
Update Alpha to Fix Edge Cases

### DIFF
--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -13205,7 +13205,6 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._imageMode = constants.CORNER;
 
   this._tint = null;
-  this._alpha = null;
   this._doStroke = true;
   this._doFill = true;
   this._strokeSet = false;
@@ -13463,7 +13462,7 @@ p5.Renderer2D.prototype.image =
   function (img, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
   var cnv;
   try {
-    if (this._tint || this._alpha) {
+    if (this._tint || (this._alpha < 1)) {
       if (p5.MediaElement && img instanceof p5.MediaElement) {
         img.loadPixels();
       }
@@ -13513,7 +13512,7 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
 
   // If alpha is set, use default p5.prototype tint, only using alpha value.
   // If not alpha is set, return previous canvas.
-  if (this._alpha) {
+  if (this._alpha < 1) {
     // Set the p5 renderer tint to the current tint value.
     // Alpha stored as value between 0 to 1, but tint is stored as value between 0 and 255.
     p5.prototype._renderer = p5.prototype._renderer || {};

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -19935,12 +19935,12 @@ p5.prototype.tint = function () {
  * @param {Number} alpha  opacity of the sprite
  */
 p5.prototype.alphaTint = function () {
-  // alpha should be between 0.01 and 1
+  // Enforce that alpha is between 0 and 1
   var alpha = arguments[0];
   if (typeof alpha === "string") {
     alpha = Number(alpha);
   }
-  alpha = Math.max(alpha, 0.01);
+  alpha = Math.max(alpha, 0);
   alpha = Math.min(alpha, 1);
   this._renderer._alpha = alpha;
 };

--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -19936,7 +19936,14 @@ p5.prototype.tint = function () {
  * @param {Number} alpha  opacity of the sprite
  */
 p5.prototype.alphaTint = function () {
-  this._renderer._alpha = arguments[0];
+  // alpha should be between 0.01 and 1
+  var alpha = arguments[0];
+  if (typeof alpha === "string") {
+    alpha = Number(alpha);
+  }
+  alpha = Math.max(alpha, 0.01);
+  alpha = Math.min(alpha, 1);
+  this._renderer._alpha = alpha;
 };
 
 /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1724,6 +1724,17 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.mouseIsPressed = false;
 
+  /**
+  * Represents the opacity of the sprite, on a scale from 0 to 1, with 1 being fully
+  * opaque. Default value is 1.
+  * Read only.
+  *
+  * @property alpha
+  * @type {Number}
+  * @default 1
+  */
+  this.alpha = 1;
+
   /*
   * Width of the sprite's current image.
   * If no images or animations are set it's the width of the
@@ -2508,7 +2519,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
           push();
           tint(this.tint);
         }
-        if(this.alpha) {
+        if(this.alpha < 1) {
           push();
           alphaTint(this.alpha);
         }


### PR DESCRIPTION
Extension of this PR in the P5.js repo: https://github.com/code-dot-org/p5.js/pull/15

There are three edge cases fixed in this PR:

* Previous implementations didn't allow both tint and alpha to be applied at the same time. This PR disentangles those actions.
* This PR limits the values of alpha to be between 0 and 1. This results in consistent behavior when students input extra large or extra small numbers.
* This PR removes the default value of null. The default value is now set in lib/p5.play.js as 1 so that when a student creates a sprite and immediately looks for the alpha value, it is set to 1.

The next stage of this PR will be updating the version of P5, once the PR linked above is merged.